### PR TITLE
Disable colors in logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,15 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3120,7 +3111,6 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
 dependencies = [
- "ansi_term",
  "chrono",
  "lazy_static",
  "matchers",

--- a/http-api/Cargo.toml
+++ b/http-api/Cargo.toml
@@ -18,6 +18,6 @@ git2 = { version = "0.13", default-features = false, features = [] }
 tokio = { version = "1.2", features = ["macros", "rt", "sync"] }
 argh = { version = "0.1.4" }
 either = { version = "1.6" }
-tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing = "0.1" 
+tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "smallvec", "fmt", "chrono", "tracing-log", "json"] }
 async-trait = "0.1"

--- a/org-node/Cargo.toml
+++ b/org-node/Cargo.toml
@@ -19,5 +19,5 @@ futures = { version = "0.3" }
 thiserror = { version = "1" }
 argh = { version = "0.1.4" }
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "smallvec", "fmt", "chrono", "tracing-log", "json"] } 
 ureq = { version = "2.1.1", features = ["json"] }


### PR DESCRIPTION
The ANSI term sequences mess up Google Cloud logs.