### PR TITLE
Fix an websocket bad request issue

### DIFF
--- a/http-api/Dockerfile
+++ b/http-api/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/radicle-client-services
 COPY . .
 
 WORKDIR /usr/src/radicle-client-services/http-api
-RUN cargo install --path .
+RUN cargo install --locked --path .
 
 # Run
 FROM debian:buster-slim@sha256:c8152821b158dd171b4acf92afb0a58fc2faa179a7e0af8ace358fbe1668e99d

--- a/org-node/Cargo.toml
+++ b/org-node/Cargo.toml
@@ -21,5 +21,5 @@ argh = { version = "0.1.4" }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 ureq = { version = "2.1.1", features = ["json"] }
-ethers = { version = "0.4", features = ["ws"] }
+ethers = { version = "0.4" }
 rustc-hex = { version = "2.1" }

--- a/org-node/Dockerfile
+++ b/org-node/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/radicle-client-services
 COPY . .
 
 WORKDIR /usr/src/radicle-client-services/org-node
-RUN cargo install --path .
+RUN cargo install --locked --path .
 
 # Run
 FROM debian:buster-slim@sha256:c8152821b158dd171b4acf92afb0a58fc2faa179a7e0af8ace358fbe1668e99d


### PR DESCRIPTION
Cause: cargo install was selecting a different dependency plan than
       outside of a container due to 'cargo install' ignoring Cargo.lock
       by default.