### PR TITLE
Add Caddy reverse proxy for automatic TLS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,14 @@ services:
     init: true
     container_name: http-api
     restart: unless-stopped
+  caddy:
+    image: caddy:2.4.5
+    ports:
+      - 80:80
+      - 443:443
+    command: caddy reverse-proxy --from $DOMAIN --to http-api:8777
+    depends_on:
+      - http-api
   org-node:
     image: gcr.io/radicle-services/org-node:$DOCKER_TAG
     build:


### PR DESCRIPTION
It requires the `DOMAIN` environment variable be set up for the TLS to work without a warning on the web browser side of things.  E.g. `export DOMAIN=example.com`.