### PR TITLE
[git-server] hooks for `receive-pack` (git push) events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,13 +29,44 @@ dependencies = [
 
 [[package]]
 name = "aes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+dependencies = [
+ "aes-soft",
+ "aesni",
+ "cipher 0.2.5",
+]
+
+[[package]]
+name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
+dependencies = [
+ "cipher 0.2.5",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "aesni"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
+dependencies = [
+ "cipher 0.2.5",
  "opaque-debug 0.3.0",
 ]
 
@@ -232,6 +263,12 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+
+[[package]]
+name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
@@ -301,6 +338,12 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "bitflags"
@@ -398,6 +441,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-cipher"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-modes"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9b14fd8a4739e6548d4b6018696cf991dcf8c6effd9ef9eb33b29b8a650972"
+dependencies = [
+ "block-cipher",
+ "block-padding 0.2.1",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +486,17 @@ dependencies = [
  "fastrand",
  "futures-lite",
  "once_cell",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fa6a061124e37baba002e496d203e23ba3d7b73750be82dbfbc92913048a5b"
+dependencies = [
+ "byteorder",
+ "cipher 0.2.5",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -545,12 +618,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast5"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1285caf81ea1f1ece6b24414c521e625ad0ec94d880625c20f2e65d8d3f78823"
+dependencies = [
+ "byteorder",
+ "cipher 0.2.5",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 dependencies = [
  "jobserver",
+]
+
+[[package]]
+name = "cfb-mode"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6975e91054798d325f85f50115056d7deccf6817fe7f947c438ee45b119632"
+dependencies = [
+ "cipher 0.2.5",
 ]
 
 [[package]]
@@ -610,11 +703,35 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "circular"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fc239e0f6cb375d2402d48afb92f76f5404fd1df208a41930ec81eda078bea"
+
+[[package]]
+name = "clear_on_drop"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -745,6 +862,12 @@ name = "cpuid-bool"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+
+[[package]]
+name = "crc24"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
 
 [[package]]
 name = "crc32fast"
@@ -887,7 +1010,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
- "cipher",
+ "cipher 0.3.0",
 ]
 
 [[package]]
@@ -901,6 +1024,41 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -958,6 +1116,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
 dependencies = [
  "const-oid",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+dependencies = [
+ "darling",
+ "derive_builder_core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "des"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b24e7c748888aa2fa8bce21d8c64a52efc810663285315ac7476f7197a982fae"
+dependencies = [
+ "byteorder",
+ "cipher 0.2.5",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -1032,6 +1226,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.8",
+ "zeroize",
+]
+
+[[package]]
 name = "ed25519-zebra"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,12 +1298,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "envconfig"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea81cc7e21f55a9d9b1efb6816904978d0bfbe31a50347cb24b2e75564bcac9b"
+dependencies = [
+ "envconfig_derive",
+]
+
+[[package]]
+name = "envconfig_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfca278e5f84b45519acaaff758ebfa01f18e96998bc24b8f1b722dd804b9bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "eth-keystore"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d47d900a7dea08593d398104f8288e37858b0ad714c8d08cd03fdb86563e6402"
 dependencies = [
- "aes",
+ "aes 0.7.5",
  "ctr",
  "digest 0.9.0",
  "hex",
@@ -1554,7 +1791,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -1585,7 +1822,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "futures 0.1.31",
  "futures-channel",
  "futures-core",
@@ -1639,7 +1876,7 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "serde",
  "typenum",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -1961,6 +2198,8 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe",
+ "openssl-sys",
  "url",
 ]
 
@@ -2043,7 +2282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
 dependencies = [
  "ahash",
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -2223,6 +2462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,7 +2559,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "hashbrown 0.11.2",
 ]
 
@@ -2465,6 +2710,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -2498,9 +2746,17 @@ source = "git+https://github.com/radicle-dev/git2-rs.git?rev=ae027b9e7b125f56397
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "librad"
@@ -2573,6 +2829,20 @@ dependencies = [
  "uuid",
  "webpki",
  "xorf",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2732,6 +3002,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2743,7 +3024,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -2795,7 +3076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -2947,13 +3228,23 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+dependencies = [
+ "memchr",
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "lexical-core",
  "memchr",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -2966,7 +3257,7 @@ dependencies = [
  "funty",
  "lexical-core",
  "memchr",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -2977,7 +3268,7 @@ checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
 dependencies = [
  "memchr",
  "minimal-lexical",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -3026,12 +3317,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d51546d704f52ef14b3c962b5776e53d5b862e5790e40a350d366c209bd7f7a"
+dependencies = [
+ "autocfg 0.1.7",
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.7.3",
+ "serde",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3041,7 +3384,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -3129,7 +3472,7 @@ version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cc",
  "libc",
  "pkg-config",
@@ -3244,6 +3587,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
+dependencies = [
+ "base64 0.13.0",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,6 +3610,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
+]
+
+[[package]]
+name = "pgp"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "856124b4d0a95badd3e1ad353edd7157fc6c6995767b78ef62848f3b296405ff"
+dependencies = [
+ "aes 0.6.0",
+ "base64 0.12.3",
+ "bitfield",
+ "block-modes",
+ "block-padding 0.2.1",
+ "blowfish",
+ "buf_redux",
+ "byteorder",
+ "cast5",
+ "cfb-mode",
+ "chrono",
+ "cipher 0.2.5",
+ "circular",
+ "clear_on_drop",
+ "crc24",
+ "derive_builder",
+ "des",
+ "digest 0.9.0",
+ "ed25519-dalek",
+ "flate2",
+ "generic-array 0.14.4",
+ "hex",
+ "lazy_static",
+ "log",
+ "md-5",
+ "nom 4.2.3",
+ "num-bigint-dig",
+ "num-derive",
+ "num-traits",
+ "rand 0.7.3",
+ "ripemd160",
+ "rsa",
+ "sha-1",
+ "sha2 0.9.8",
+ "sha3",
+ "signature",
+ "smallvec",
+ "thiserror",
+ "try_from",
+ "twofish",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -3433,7 +3837,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf40e51ccefb72d42720609e1d3c518de8b5800d723a09358d4a6d6245e1f8ca"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "indexmap",
 ]
 
@@ -3457,7 +3861,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -3468,7 +3872,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -3636,7 +4040,13 @@ version = "0.1.0"
 dependencies = [
  "argh",
  "base64 0.13.0",
+ "envconfig",
+ "git2",
+ "hex",
  "http",
+ "librad",
+ "pgp",
+ "rand 0.8.4",
  "shared",
  "thiserror",
  "tokio",
@@ -3878,7 +4288,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -4048,6 +4458,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3648b669b10afeab18972c105e284a7b953a669b0be3514c27f9b17acab2f9cd"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "lazy_static",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pem",
+ "rand 0.7.3",
+ "sha2 0.9.8",
+ "simple_asn1",
+ "subtle",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4129,7 +4561,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
 dependencies = [
- "cipher",
+ "cipher 0.3.0",
 ]
 
 [[package]]
@@ -4465,6 +4897,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
+dependencies = [
+ "chrono",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
 name = "sized-vec"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4543,7 +4986,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -4609,6 +5052,12 @@ checksum = "09f8ed9974042b8c3672ff3030a69fcc03b74c47c3d1ecb7755e8a3626011e88"
 dependencies = [
  "generic-array 0.14.4",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "subtle"
@@ -4767,7 +5216,7 @@ dependencies = [
  "standback",
  "stdweb",
  "time-macros",
- "version_check",
+ "version_check 0.9.3",
  "winapi 0.3.9",
 ]
 
@@ -4833,7 +5282,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "bytes 1.1.0",
  "libc",
  "memchr",
@@ -5057,6 +5506,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "try_from"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
+dependencies = [
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5095,6 +5553,17 @@ dependencies = [
  "url",
  "utf-8",
  "webpki",
+]
+
+[[package]]
+name = "twofish"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0028f5982f23ecc9a1bc3008ead4c664f843ed5d78acd3d213b99ff50c441bc2"
+dependencies = [
+ "byteorder",
+ "cipher 0.2.5",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -5145,7 +5614,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -5249,6 +5718,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -5543,6 +6018,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
+name = "x25519-dalek"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
 name = "xattr"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5577,9 +6063,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]

--- a/git-server/Cargo.toml
+++ b/git-server/Cargo.toml
@@ -6,16 +6,36 @@ authors = ["Alexis Sellier <self@cloudhead.io>"]
 edition = "2018"
 build = "../build.rs"
 
+[[bin]]
+name = "pre-receive"
+path = "bin/pre_receive.rs"
+required-features = ["hooks"]
+
+[[bin]]
+name = "post-receive"
+path = "bin/post_receive.rs"
+required-features = ["hooks"]
+
 [dependencies]
-base64 = { version = "0.13" }
-shared = { path = "../shared", default-features = false }
-warp = { version = "0.3.1", features = ["tls"] }
-http = { version = "0.2" }
-thiserror = { version = "1" }
-tokio = { version = "1.2", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 argh = { version = "0.1.4" }
+base64 = { version = "0.13" }
+git2 = "0.13"
+http = { version = "0.2" }
+librad = { version = "0" }
+shared = { path = "../shared", default-features = false }
+thiserror = { version = "1.0" }
+tokio = { version = "1.2", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
+warp = { version = "0.3.1", features = ["tls"] }
+
+# hooks feature enabled dependencies
+envconfig = { version = "0.10.0", optional = true }
+pgp = { version = "0.7.2", optional = true }
+hex = { version = "0.4.3", optional = true }
+rand = "0.8.4"
 
 [features]
 gcp = ["shared/gcp"]
+hooks = ["envconfig", "pgp", "hex"]
+

--- a/git-server/Dockerfile
+++ b/git-server/Dockerfile
@@ -13,5 +13,7 @@ FROM debian:buster-slim@sha256:c8152821b158dd171b4acf92afb0a58fc2faa179a7e0af8ac
 EXPOSE 8778/tcp
 RUN apt-get update && apt-get install -y libssl1.1 git && rm -rf /var/lib/apt/lists/*
 COPY --from=build /usr/local/cargo/bin/radicle-git-server /usr/local/bin/radicle-git-server
+
 WORKDIR /app/radicle
+
 ENTRYPOINT ["/usr/local/bin/radicle-git-server", "--root", "/app/radicle/root", "--listen", "0.0.0.0:8778"]

--- a/git-server/README.md
+++ b/git-server/README.md
@@ -5,3 +5,41 @@
 # Running
 
     $ radicle-git-server --root ~/.radicle
+
+# Git Hooks
+
+Git [hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) are used by the git http backend to manage requests made to a repository, such as a `push` action. Hooks are executable files that accept standard input, perform some action and return an exit status back to the sender of the request, either successfully completing the request or declining.
+
+This crate includes a `bin` folder that contains hooks used by the `radicle-git-server` for authorizing requests and performing other tasks.
+
+In order to use these hooks, the binaries in the `bin` folder must be built using `cargo build --bin pre-receive --feature hooks` and `cargo build --bin post-receive --feature hooks` (`--release` for production) and moved to the radicle root under `git/hooks/` (e.g. `~/.radicle/git/hooks/`) folder. These executables will automatically be called by the http-backend.
+
+## Authorizing Signed Push Certificates in `pre-receive` Hook
+
+The `pre-receive` hook is the first hook invoked by the git http-backend when a `receive-pack` event is triggered from a `git push` client request.
+
+The `pre-receive` hook is used to verify the git signed push certificates from the sender, e.g. `git push --signed ...`. Unless the `git-server` is run with the `--allow-unauthorized-keys` flag, any unsigned git push will be denied by the `pre-receive` hook.
+
+### Allow Unauthorized Keys
+
+While developing it can sometimes be useful to disable certificate verification and key authorization. To disable certificate checking, run the `git-server` with the following command:
+
+```
+radicle-git-server ... --allow-unauthorized-keys
+```
+
+### Providing a Command Line Argument Authorized Keyring
+
+It is possible to provide the `git-server` with a comma delimited list of authorized GPG key fingerprints to use as a simple keyring for verifying a signed push certificate. To set an authorized keys list, run the `git-server` with the following command:
+
+```
+radicle-git-server ... --authorized-keys 817EEFE32E1F0AA5,...,...
+```
+
+### Using `.rad/keys/openpgp/<key_id>` for Authorization
+
+By default, the `pre-receive` hook will check the target repository for a `.rad/keys/openpgp/<key_id>` public key file on push. If it exists, it will check the public key's fingerprint matches the `$GIT_PUSH_CERT_KEY` set by the http-backend. The `$GIT_PUSH_CERT_KEY` is used to find the file in the namespace tree, comparing the fingerprint in the authorized keyring against the signed certificate.
+
+No `git-server` command arguments are needed to perform this check.
+
+In order to setup your `.rad/keys/` keyring, there is a CLI tool, `rad-auth-keys`, in `radicle-client-tools/authorized-keys` that provides helper commands for exporting your gpg key and placing it into your `.rad/keys/` keyring.

--- a/git-server/bin/post_receive.rs
+++ b/git-server/bin/post_receive.rs
@@ -1,0 +1,20 @@
+//! `post-receive` git hook binary.
+
+use radicle_git_server::error::Error;
+
+#[cfg(feature = "hooks")]
+fn main() -> Result<(), Error> {
+    use radicle_git_server::hooks::post_receive::PostReceive;
+
+    match PostReceive::hook() {
+        Ok(()) => {
+            println!("post-receive hook success");
+            std::process::exit(0)
+        }
+        Err(e) => {
+            eprintln!("{:?}", e);
+            // exit with error and decline the post-receive;
+            std::process::exit(1)
+        }
+    }
+}

--- a/git-server/bin/pre_receive.rs
+++ b/git-server/bin/pre_receive.rs
@@ -1,0 +1,21 @@
+//! `pre-receive` git hook binary.
+
+use radicle_git_server::error::Error;
+
+#[cfg(feature = "hooks")]
+fn main() -> Result<(), Error> {
+    use radicle_git_server::hooks::pre_receive::PreReceive;
+
+    // run the `pre-receive` hook
+    match PreReceive::hook() {
+        Ok(()) => {
+            println!("pre-receive hook success");
+            std::process::exit(0)
+        }
+        Err(e) => {
+            eprintln!("{:?}", e);
+            // exit with error and decline the pre-receive;
+            std::process::exit(1)
+        }
+    }
+}

--- a/git-server/src/error.rs
+++ b/git-server/src/error.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::large_enum_variant)]
 
-/// Errors that may occur when interacting with [`librad::net::peer::Peer`].
+/// Errors that may occur when interacting with the radicle git server or git hooks.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// I/O error.
@@ -27,9 +27,59 @@ pub enum Error {
     #[error("invalid authorization")]
     InvalidAuthorization,
 
+    /// Failed certificate verification.
+    #[error("failed certification verification")]
+    FailedCertificateVerification,
+
     /// Unauthorized.
     #[error("unauthorized")]
     Unauthorized,
+
+    /// Namespace not found.
+    #[error("namespace does not exist;")]
+    NamespaceNotFound,
+
+    /// Reference not found.
+    #[error("reference not found")]
+    ReferenceNotFound,
+
+    /// Radicle identity not found for project.
+    #[error("radicle identity is not found for project")]
+    RadicleIdentityNotFound,
+
+    /// Environmental variable error.
+    #[error("environmental variable error: {0}")]
+    VarError(#[from] std::env::VarError),
+
+    /// Git config parser error.
+    #[error("git2 error: {0:?}")]
+    Git2Error(#[from] git2::Error),
+
+    /// Missing certification signer credentials.
+    #[error("missing certificate signer credentials: {0:?}")]
+    MissingCertificateSignerCredentials(String),
+
+    /// Missing environmental variable.
+    #[cfg(feature = "hooks")]
+    #[error("missing environmental config variable: {0:?}")]
+    EnvConfigError(#[from] envconfig::Error),
+
+    /// Failed to parse byte data into string.
+    #[error(transparent)]
+    Utf8Error(#[from] std::str::Utf8Error),
+
+    /// OpenPGP errors.
+    #[cfg(feature = "hooks")]
+    #[error(transparent)]
+    PgpError(#[from] pgp::errors::Error),
+
+    /// Librad profile error.
+    #[error(transparent)]
+    Profile(#[from] librad::profile::Error),
+
+    /// Failed to connect to org-node unix socket.
+    #[error("failed to connect to org-node unix socket")]
+    UnixSocket,
 }
 
 impl Error {

--- a/git-server/src/hooks/mod.rs
+++ b/git-server/src/hooks/mod.rs
@@ -1,0 +1,40 @@
+pub mod post_receive;
+pub mod pre_receive;
+pub mod types;
+
+use crate::error::Error;
+
+/// Trait for shared default methods for accessing
+/// GPG signed push certificate detail information, such as
+/// signer name and email set in the `$GIT_PUSH_CERT_SIGNER` env.
+///
+/// e.g. `First Last <first.last@email.com>`
+pub trait CertSignerDetails {
+    /// returns the name of the GPG signer set from the `$GIT_PUSH_CERT_SIGNER` env.
+    fn signer_name(cert_signer: Option<String>) -> Result<String, Error> {
+        if let Some(signer) = cert_signer {
+            let end = signer.find('<').unwrap_or_else(|| signer.len()) - 1;
+
+            return Ok(signer[0..end].to_owned());
+        }
+
+        Err(Error::MissingCertificateSignerCredentials(
+            "name".to_string(),
+        ))
+    }
+
+    /// returns the email of the GPG signer set from the `$GIT_PUSH_CERT_SIGNER` env.
+    fn signer_email(cert_signer: Option<String>) -> Result<String, Error> {
+        if let Some(signer) = cert_signer {
+            if let Some(start) = signer.find('<') {
+                if let Some(end) = signer.find('>') {
+                    return Ok(signer[start + 1..end].to_owned());
+                }
+            }
+        }
+
+        Err(Error::MissingCertificateSignerCredentials(
+            "email".to_string(),
+        ))
+    }
+}

--- a/git-server/src/hooks/post_receive.rs
+++ b/git-server/src/hooks/post_receive.rs
@@ -1,0 +1,88 @@
+//! # POST-RECEIVE HOOK
+//!
+//! <https://git-scm.com/docs/githooks#post-receive>
+//!
+//! # Use by Radicle Git-Server
+//!
+//! The `post-receive` git hook sends a request to the org-node for signing references once a `git push` has successfully passed
+//! `pre-receive` certification verification and authorization.
+//!
+//!
+use std::io::{stdin, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+
+use envconfig::Envconfig;
+use git2::Oid;
+
+use super::{types::ReceivePackEnv, CertSignerDetails};
+use crate::error::Error;
+
+/// Filename for named pipe / FIFO file.
+pub const ORG_SOCKET_FILE: &str = "org-node.sock";
+
+/// `PostReceive` provides access to the standard input values passed into the `post-receive`
+/// git hook, as well as parses environmental variables that may be used to process the hook.
+#[derive(Debug, Clone)]
+pub struct PostReceive {
+    // Old SHA1
+    pub old: Oid,
+    // New SHA1
+    pub new: Oid,
+    // refname relative to $GIT_DIR
+    pub refname: String,
+    // Environmental variables.
+    pub env: ReceivePackEnv,
+}
+
+// use cert signer details default utility implementations.
+impl CertSignerDetails for PostReceive {}
+
+impl PostReceive {
+    /// Instantiate from standard input.
+    pub fn from_stdin() -> Result<Self, Error> {
+        let mut buffer = String::new();
+        stdin().read_to_string(&mut buffer)?;
+
+        let input = buffer.split(' ').collect::<Vec<&str>>();
+
+        // parse standard input variables.
+        let old = Oid::from_str(input[0])?;
+        let new = Oid::from_str(input[1])?;
+        let refname = input[2].replace("\n", "");
+
+        // initialize environmental values.
+        let env = ReceivePackEnv::init_from_env()?;
+
+        Ok(Self {
+            old,
+            new,
+            refname,
+            env,
+        })
+    }
+
+    /// The main process used by `post-receive` hook.
+    pub fn hook() -> Result<(), Error> {
+        let post_receive = Self::from_stdin()?;
+
+        // notify the org-node to update the signed refs.
+        post_receive.notify_org_node()
+    }
+
+    pub fn notify_org_node(&self) -> Result<(), Error> {
+        let path = PathBuf::from(&self.env.git_project_root).join(ORG_SOCKET_FILE);
+        match UnixStream::connect(path.clone()) {
+            Ok(mut stream) => {
+                stream.write_all(format!("{}\n", self.env.git_namespace).as_bytes())?;
+            }
+            Err(e) => {
+                eprintln!("Error connecting to org socket ({:?}): {}", path, e);
+                eprintln!("Please ensure org-node service is running.");
+                return Err(Error::UnixSocket);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/git-server/src/hooks/pre_receive.rs
+++ b/git-server/src/hooks/pre_receive.rs
@@ -1,0 +1,205 @@
+//! # PRE-RECEIVE HOOK
+//!
+//! Before any ref is updated, if $GIT_DIR/hooks/pre-receive file exists and is executable,
+//! it will be invoked once with no parameters.
+//!
+//! The standard input of the hook will be one line per ref to be updated:
+
+//! `sha1-old SP sha1-new SP refname LF`
+//!
+//! The refname value is relative to $GIT_DIR; e.g. for the master head this is "refs/heads/master".
+//! The two sha1 values before each refname are the object names for the refname before and after the update.
+//! Refs to be created will have sha1-old equal to 0{40}, while refs to be deleted will have sha1-new equal to 0{40},
+//! otherwise sha1-old and sha1-new should be valid objects in the repository.
+//!
+//! # Use by Radicle Git-Server
+//!
+//! The `pre-receive` git hook provides access to GPG certificates for a signed push, useful for authorizing an
+//! update the repository.
+use std::io::{stdin, Read};
+use std::path::Path;
+use std::str::FromStr;
+
+use envconfig::Envconfig;
+use git2::{Oid, Repository};
+use pgp::{types::KeyTrait, Deserializable};
+
+use super::{
+    types::{CertNonceStatus, ReceivePackEnv},
+    CertSignerDetails,
+};
+use crate::error::Error;
+
+pub type KeyRing = Vec<String>;
+
+pub const DEFAULT_RAD_KEYS_PATH: &str = ".rad/keys/openpgp/";
+
+/// `PreReceive` provides access to the standard input values passed into the `pre-receive`
+/// git hook, as well as parses environmental variables that may be used to process the hook.
+#[derive(Debug, Clone)]
+pub struct PreReceive {
+    // Old SHA1
+    pub old: Oid,
+    // New SHA1
+    pub new: Oid,
+    // refname relative to $GIT_DIR
+    pub refname: String,
+    // Environmental Variables;
+    pub env: ReceivePackEnv,
+}
+
+// use cert signer details default utility implementations.
+impl CertSignerDetails for PreReceive {}
+
+impl PreReceive {
+    /// Instantiate from standard input.
+    pub fn from_stdin() -> Result<Self, Error> {
+        let mut buffer = String::new();
+        stdin().read_to_string(&mut buffer)?;
+
+        let input = buffer.split(' ').collect::<Vec<&str>>();
+
+        // parse standard input variables;
+        let old = Oid::from_str(input[0])?;
+        let new = Oid::from_str(input[1])?;
+        let refname = input[2].replace("\n", "");
+
+        // initialize environmental values.
+        let env = ReceivePackEnv::init_from_env()?;
+
+        Ok(Self {
+            old,
+            new,
+            refname,
+            env,
+        })
+    }
+
+    /// The main process used by `pre-receive` hook log
+    pub fn hook() -> Result<(), Error> {
+        let pre_receive = Self::from_stdin()?;
+
+        // check if project exists.
+        pre_receive.check_project_exists()?;
+
+        // if allowed authorized keys is enabled, bypass the certificate check.
+        if pre_receive.env.allow_unauthorized_keys {
+            println!("SECURITY ALERT! UNAUTHORIZED KEYS ARE ALLOWED!");
+            println!("Remove git-server flag `--allow-authorized-keys` to enforce GPG certificate verification");
+            Ok(())
+        } else {
+            // Authenticate the request.
+            pre_receive.authenticate()
+        }
+    }
+
+    /// Authenticate the request by verifying the push signed certificate is valid and the GPG
+    /// signing key is included in an authorized keyring.
+    pub fn authenticate(&self) -> Result<(), Error> {
+        // verify the certificate.
+        self.verify_certificate()?;
+
+        // ensure is authorized keys.
+        self.check_authorized_key()?;
+
+        Ok(())
+    }
+
+    pub fn check_project_exists(&self) -> Result<(), Error> {
+        let repo = Repository::open(&self.env.git_dir)?;
+
+        // set the namespace for the repo equal to the git namespace env.
+        if repo.set_namespace(&self.env.git_namespace).is_err() {
+            return Err(Error::NamespaceNotFound);
+        }
+
+        // check if the project has a radicle identity.
+        if repo.find_reference("refs/rad/id").is_err() {
+            return Err(Error::RadicleIdentityNotFound);
+        }
+
+        Ok(())
+    }
+
+    /// This method will succeed iff the cert status is "OK"
+    pub fn verify_certificate(&self) -> Result<(), Error> {
+        let status =
+            CertNonceStatus::from_str(&self.env.cert_nonce_status.clone().unwrap_or_default())?;
+        match status {
+            // If we receive "OK", the certificate is verified using GPG.
+            CertNonceStatus::OK => return Ok(()),
+            // Received an invalid certificate status
+            CertNonceStatus::UNKNOWN => {
+                eprintln!("Invalid request, please sign push, i.e. `git push --sign ...`");
+            }
+            CertNonceStatus::SLOP => {
+                eprintln!("Received `SLOP` certificate status, please re-submit signed push to request new certificate");
+            }
+            _ => {
+                eprintln!("Received invalid certificate nonce status: {:?}", status);
+            }
+        }
+
+        Err(Error::FailedCertificateVerification)
+    }
+
+    /// Check if the cert_key is found in an authorized keyring
+    pub fn check_authorized_key(&self) -> Result<(), Error> {
+        if let Some(key) = &self.env.cert_key {
+            if self.authorized_keys()?.contains(key) || self.is_cert_authorized()? {
+                // exit early, the key is included in the authorized keys list.
+                return Ok(());
+            }
+
+            eprintln!("Unauthorized GPG Key: {:?}", key);
+        }
+
+        Err(Error::Unauthorized)
+    }
+
+    /// Return the parsed authorized keys from the provided environmental variable.
+    pub fn authorized_keys(&self) -> Result<KeyRing, Error> {
+        Ok(self
+            .env
+            .radicle_authorized_keys
+            .clone()
+            .map(|k| k.split(',').map(|k| k.to_owned()).collect::<KeyRing>())
+            .unwrap_or_default())
+    }
+
+    /// Check the local repo .rad/keys/ directory for the GPG key matching the cert key
+    /// used to sign the push certificate.
+    pub fn is_cert_authorized(&self) -> Result<bool, Error> {
+        if let Some(key) = self.env.cert_key.clone() {
+            // search for the public key in the rad keys directory.
+            let repo = Repository::open(&self.env.git_dir)?;
+
+            // the path of the public key to verify.
+            let key_path = Path::new(DEFAULT_RAD_KEYS_PATH).join(&key);
+
+            // set the namespace for the repo equal to the git namespace env.
+            repo.set_namespace(&self.env.git_namespace)?;
+
+            let rfc = repo.find_reference(&self.refname)?;
+
+            if let Ok(tree) = rfc.peel_to_tree() {
+                if let Ok(entry) = tree.get_path(&key_path) {
+                    let obj = entry.to_object(&repo)?;
+                    let blob = obj.peel_to_blob()?;
+                    let content = std::str::from_utf8(blob.content())?;
+                    let (pk, _) = pgp::SignedPublicKey::from_string(content)?;
+
+                    // verify the key on file.
+                    pk.verify()?;
+
+                    let key_id = hex::encode(pk.primary_key.key_id().as_ref()).to_uppercase();
+
+                    // check the key matches the key from the signed push certificate.
+                    return Ok(key_id == key);
+                }
+            };
+        }
+
+        Ok(false)
+    }
+}

--- a/git-server/src/hooks/types.rs
+++ b/git-server/src/hooks/types.rs
@@ -1,0 +1,150 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use crate::error::Error;
+
+use envconfig::Envconfig;
+
+/// `CertNonceStatus` describes the status of verifying the signed nonce from
+/// the user. If it does not match "OK", the `pre-receive` hook should fail unsuccessfully
+#[derive(Debug, Clone)]
+pub enum CertNonceStatus {
+    /// "git push --signed" sent a nonce when we did not ask it to send one.
+    UNSOLICITED,
+    /// "git push --signed" did not send any nonce header.
+    MISSING,
+    /// "git push --signed" sent a bogus nonce.
+    BAD,
+    /// "git push --signed" sent the nonce we asked it to send.
+    OK,
+    /// "git push --signed" sent a nonce different from what we asked it to send now, but in a previous session.
+    /// See GIT_PUSH_CERT_NONCE_SLOP environment variable.
+    SLOP,
+    /// Unknown type; not associated with git.
+    UNKNOWN,
+}
+
+impl Default for CertNonceStatus {
+    fn default() -> Self {
+        Self::UNKNOWN
+    }
+}
+
+impl FromStr for CertNonceStatus {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<CertNonceStatus, Self::Err> {
+        Ok(match s {
+            "UNSOLICITED" => Self::UNSOLICITED,
+            "MISSING" => Self::MISSING,
+            "BAD" => Self::BAD,
+            "OK" => Self::OK,
+            "SLOP" => Self::SLOP,
+            _ => Self::UNKNOWN,
+        })
+    }
+}
+
+/// `ReceivePackEnv` provides access to environmental variables set and used by git-http-backend
+/// when a `receive-pack` event is triggered. The values are used by both the `pre-receive` and `post-receive`
+/// hooks within the `receive-pack` hook lifecycle.
+///
+/// Certificate variables are set by the git-http-backend process, while other variables are set
+/// when receiving a new git client request and passing those variables to http-backend.
+///
+/// These variables are not exhaustive; other variables may be set by the backend process, but are unused.
+#[derive(Debug, Default, Clone, Envconfig)]
+pub struct ReceivePackEnv {
+    /// Object Id of the blob where the signed certificate exists.
+    #[envconfig(from = "GIT_PUSH_CERT")]
+    pub cert: Option<String>,
+
+    /// The name and the e-mail address of the owner of the key that signed the push certificate.
+    #[envconfig(from = "GIT_PUSH_CERT_SIGNER")]
+    pub cert_signer: Option<String>,
+
+    /// The GPG key ID of the key that signed the push certificate.
+    #[envconfig(from = "GIT_PUSH_CERT_KEY")]
+    pub cert_key: Option<String>,
+
+    /// The status of GPG verification of the push certificate,
+    /// using the same mnemonic as used in %G? format of git log family of commands (see [git-log](https://git-scm.com/docs/git-log)).
+    #[envconfig(from = "GIT_PUSH_CERT_STATUS")]
+    pub cert_status: Option<String>,
+
+    /// The nonce string the process asked the signer to include in the push certificate.
+    /// If this does not match the value recorded on the "nonce" header in the push certificate,
+    /// it may indicate that the certificate is a valid one that is being replayed from a separate "git push" session.
+    #[envconfig(from = "GIT_PUSH_CERT_NONCE")]
+    pub cert_nonce: Option<String>,
+
+    /// cert nonce status is used as a determinant whether the certificate was correctly signed by the user.
+    /// only an `OK` status will be accepted for authorization.
+    #[envconfig(from = "GIT_PUSH_CERT_NONCE_STATUS")]
+    pub cert_nonce_status: Option<String>,
+
+    /// "git push --signed" sent a nonce different from what we asked it to send now,
+    /// but in a different session whose starting time is different by this many seconds from the current session.
+    /// Only meaningful when GIT_PUSH_CERT_NONCE_STATUS says SLOP.
+    /// Also read about receive.certNonceSlop variable in [git-config](https://git-scm.com/docs/git-config).
+    #[envconfig(from = "GIT_PUSH_CERT_NONCE_SLOP")]
+    pub cert_nonce_slop: Option<String>,
+
+    /// comma delimited list of gpg key strings used for authorizing gpg identity
+    #[envconfig(from = "RADICLE_AUTHORIZED_KEYS")]
+    pub radicle_authorized_keys: Option<String>,
+
+    /// allow unauthorized keys, ignores gpg certificate verification.
+    #[envconfig(from = "RADICLE_ALLOW_UNAUTHORIZED_KEYS")]
+    pub allow_unauthorized_keys: bool,
+
+    /// root directory where `git` directory is found.
+    #[envconfig(from = "GIT_PROJECT_ROOT")]
+    pub git_project_root: String,
+
+    /// namespace of the target repository.
+    #[envconfig(from = "GIT_NAMESPACE")]
+    pub git_namespace: String,
+
+    /// The backend process sets GIT_COMMITTER_NAME to $REMOTE_USER
+    /// and GIT_COMMITTER_EMAIL to ${REMOTE_USER}@http.${REMOTE_ADDR},
+    /// ensuring that any reflogs created by git-receive-pack contain
+    /// some identifying information of the remote user who performed
+    /// the push.
+    ///
+    /// NOTE: `remote_user` and `remote_addr` are set by http basic
+    /// authentication: i.e. username and password
+    ///
+    /// `git-receive-pack` and `pre-receive` hook check for a signed push,
+    /// which if remote user is set, it should match the signer of the push
+    /// to verify basic authentication matches signer email.
+    #[envconfig(from = "REMOTE_USER")]
+    pub remote_user: Option<String>,
+
+    /// remote address of the socket making the request to the git-server.
+    /// set by the git-server.
+    #[envconfig(from = "REMOTE_ADDR")]
+    pub remote_addr: Option<String>,
+
+    /// should match `REMOTE_USER`
+    #[envconfig(from = "GIT_COMMITTER_NAME")]
+    pub git_committer_name: Option<String>,
+
+    /// GIT_COMMITTER_EMAIL is set to ${REMOTE_USER}@http.${REMOTE_ADDR} by the git-http-backend;
+    /// NOTE: it will likely not match the certificate signer email, as these values are set
+    /// by different tools and services.
+    #[envconfig(from = "GIT_COMMITTER_EMAIL")]
+    pub git_committer_email: Option<String>,
+
+    /// HTTP header set by the git-server.
+    #[envconfig(from = "CONTENT_TYPE")]
+    pub content_type: String,
+
+    /// HTTP query string set by the git-server.
+    #[envconfig(from = "QUERY_STRING")]
+    pub query_string: String,
+
+    /// top-level git directory, set by the git-http-backend.
+    #[envconfig(from = "GIT_DIR")]
+    pub git_dir: PathBuf,
+}

--- a/git-server/src/main.rs
+++ b/git-server/src/main.rs
@@ -16,7 +16,7 @@ pub struct Options {
 
     /// radicle root path, for key and git storage
     #[argh(option)]
-    pub root: PathBuf,
+    pub root: Option<PathBuf>,
 
     /// TLS certificate path
     #[argh(option)]
@@ -33,6 +33,18 @@ pub struct Options {
     /// service 'git-receive-pack' operations, eg. resulting from a `git push` (default: false)
     #[argh(switch)]
     pub git_receive_pack: bool,
+
+    /// list of comma delimited GPG authorized keys to verify a signed push
+    #[argh(option)]
+    pub authorized_keys: Option<String>,
+
+    /// certificate nonce seed used to enable `push --signed`
+    #[argh(option)]
+    pub cert_nonce_seed: Option<String>,
+
+    /// allow unauthorized keys, ignores gpg certificate verification
+    #[argh(switch)]
+    pub allow_unauthorized_keys: bool,
 }
 
 impl Options {
@@ -49,6 +61,12 @@ impl From<Options> for server::Options {
             tls_key: other.tls_key,
             listen: other.listen,
             git_receive_pack: other.git_receive_pack,
+            authorized_keys: other
+                .authorized_keys
+                .map(|k| k.split(',').map(|s| s.to_owned()).collect::<Vec<String>>())
+                .unwrap_or_default(),
+            cert_nonce_seed: other.cert_nonce_seed,
+            allow_unauthorized_keys: other.allow_unauthorized_keys,
         }
     }
 }


### PR DESCRIPTION
Authenticates git push requests using signed push certificates, e.g. `git push --sign`, verified in the newly created `pre-receive` hook  binary.

Additionally sends a request over unix sockets to `org-node` to update the signed refs, handled in the newly created `post-receive` hook binary.