### PR TITLE
Fix org-node replication

### DIFF
--- a/org-node/Dockerfile
+++ b/org-node/Dockerfile
@@ -13,7 +13,7 @@ RUN cargo install --all-features --locked --path .
 FROM debian:buster-slim@sha256:c8152821b158dd171b4acf92afb0a58fc2faa179a7e0af8ace358fbe1668e99d
 
 EXPOSE 8776/udp
-RUN apt-get update && apt-get install -y libssl1.1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libssl1.1 git && rm -rf /var/lib/apt/lists/*
 COPY --from=build /usr/local/cargo/bin/radicle-org-node /usr/local/bin/radicle-org-node
 WORKDIR /app/radicle
 ENTRYPOINT [ \


### PR DESCRIPTION
This fixes the issue where replication wasn't working on the 2nd hop after a maintainer had already pushed the repo onto an org node.

All credit goes to @geigerzaehler for finding this one.

For testing this we deployed this to the Upstream org node.
Tested it like this:
1. download latest Upstream from https://radicle.xyz/downloads.html
2. install and onboard
3. remove existing seed node from the networking screen
4. add `hyncrnppok8iam6y5oemg4fkumj86mc4wsdiirp83z7tdxchk5dbn6@seed.upstream.radicle.xyz:8776`
5. restart Upstream
6. follow the Upstream project: `rad:git:hnrk8ueib11sen1g9n1xbt71qdns9n4gipw1o`

<img width="1552" alt="Screenshot 2021-10-13 at 22 00 33" src="https://user-images.githubusercontent.com/158411/137204782-e259bcbe-4871-4d6b-b329-a6b44d35f904.png">

