### PR TITLE
add `--rad-home` option to org node for compatible directory layout

### DIFF
--- a/org-node/src/lib.rs
+++ b/org-node/src/lib.rs
@@ -10,7 +10,7 @@ use ethers::abi::Address;
 use ethers::prelude::*;
 use ethers::providers::{Provider, Ws};
 
-use radicle_daemon::Paths;
+use librad::{paths::Paths, profile::Profile};
 use thiserror::Error;
 
 use futures::StreamExt;
@@ -40,7 +40,7 @@ use client::Client;
 pub type OrgId = String;
 
 pub struct Options {
-    pub root: PathBuf,
+    pub root: Option<PathBuf>,
     pub identity: PathBuf,
     pub bootstrap: Vec<(PeerId, net::SocketAddr)>,
     pub rpc_url: String,
@@ -154,7 +154,11 @@ pub fn run(rt: tokio::runtime::Runtime, options: Options) -> anyhow::Result<()> 
         .stdout;
     tracing::info!(target: "org-node", "{}", std::str::from_utf8(&git_version).unwrap().trim());
 
-    let paths = Paths::from_root(options.root.clone()).unwrap();
+    let paths = if let Some(ref root) = options.root {
+        Paths::from_root(root).unwrap()
+    } else {
+        Profile::load()?.paths().clone()
+    };
     let identity_path = options.identity.clone();
     let identity = File::open(options.identity.clone())
         .with_context(|| format!("unable to open {:?}", &identity_path))?;

--- a/org-node/src/main.rs
+++ b/org-node/src/main.rs
@@ -22,7 +22,7 @@ pub struct Options {
 
     /// radicle root path, for key and git storage
     #[argh(option)]
-    pub root: PathBuf,
+    pub root: Option<PathBuf>,
 
     /// radicle orgs subgraph (url)
     #[argh(option)]


### PR DESCRIPTION
We add the `--rad-home` option to the org node. If given instead of `--root` it stores radicle data in a manner that is compatible with other tooling like the `rad` binary and `Upstream`.

With the new option it is possible to inspect the monorepo using `rad`

    org-node --rad-home ~/.rad-home ...

    RAD_HOME=~/.rad-home rad identities project list

The change is backwards compatible. The `--root` option behaves as before.

Instead of relying on `RAD_HOME` to set the path and defaulting to XDG directories if `RAD_HOME` is not set I opted for requiring the option to avoid implicitly messing up user storage.