### PR TITLE
org-node: unlock encrypted key

### DIFF
--- a/org-node/src/client/signer.rs
+++ b/org-node/src/client/signer.rs
@@ -8,6 +8,12 @@ pub struct Signer {
     pub(super) key: SecretKey,
 }
 
+impl From<SecretKey> for Signer {
+    fn from(key: SecretKey) -> Self {
+        Self { key }
+    }
+}
+
 impl From<Signer> for PeerId {
     fn from(signer: Signer) -> Self {
         signer.key.into()

--- a/org-node/src/identity.rs
+++ b/org-node/src/identity.rs
@@ -1,0 +1,51 @@
+use std::{
+    fs::File,
+    io::{self, Read as _},
+    path::PathBuf,
+};
+
+use librad::{
+    crypto::keystore::{
+        crypto::{KdfParams, Pwhash},
+        pinentry::SecUtf8,
+        FileStorage, Keystore as _,
+    },
+    PublicKey, SecStr, SecretKey,
+};
+
+use crate::client::Signer;
+
+pub enum Identity {
+    Plain(PathBuf),
+    Encrypted { path: PathBuf, passphrase: SecUtf8 },
+}
+
+impl Identity {
+    pub fn signer(self) -> Result<Signer, io::Error> {
+        match self {
+            Self::Plain(path) => {
+                use librad::crypto::keystore::SecretKeyExt;
+
+                let mut r = File::open(path)?;
+
+                let mut bytes = Vec::new();
+                r.read_to_end(&mut bytes)?;
+
+                let sbytes: SecStr = bytes.into();
+                match SecretKey::from_bytes_and_meta(sbytes, &()) {
+                    Ok(key) => Ok(key.into()),
+                    Err(err) => Err(io::Error::new(io::ErrorKind::InvalidData, err)),
+                }
+            }
+            Self::Encrypted { path, passphrase } => {
+                let crypto = Pwhash::new(passphrase, KdfParams::recommended());
+                let store: FileStorage<_, PublicKey, SecretKey, _> =
+                    FileStorage::new(&path, crypto);
+                store
+                    .get_key()
+                    .map(|pair| pair.secret_key.into())
+                    .map_err(|err| io::Error::new(io::ErrorKind::PermissionDenied, err))
+            }
+        }
+    }
+}

--- a/org-node/src/main.rs
+++ b/org-node/src/main.rs
@@ -36,6 +36,10 @@ pub struct Options {
     #[argh(option)]
     pub identity: PathBuf,
 
+    /// passphrase to decrypt an encrypted identity file
+    #[argh(option)]
+    pub identity_passphrase: Option<String>,
+
     /// start syncing from a given unix timestamp (seconds)
     #[argh(option)]
     pub timestamp: Option<u64>,
@@ -91,6 +95,7 @@ impl From<Options> for node::Options {
             subgraph: other.subgraph,
             rpc_url: other.rpc_url,
             identity: other.identity,
+            identity_passphrase: other.identity_passphrase,
             timestamp: other.timestamp,
             bootstrap: other.bootstrap.unwrap_or_default(),
             orgs: other.orgs.unwrap_or_default(),
@@ -117,6 +122,7 @@ impl From<Options> for node::Options {
             subgraph: other.subgraph,
             rpc_url: other.rpc_url,
             identity: other.identity,
+            identity_passphrase: other.identity_passphrase,
             timestamp: other.timestamp,
             bootstrap: other.bootstrap.unwrap_or_default(),
             orgs: other.orgs.unwrap_or_default(),


### PR DESCRIPTION
This change allows an identity file to be specified that is encrypted
and stored using the FileStorage found in radicle-keystore.

It adds an optional parameter `--identity-passphrase` which expects the
passphrase that decrypts the file to get the signing key.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>