### PR TITLE
org-node: add web server and web socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite 0.15.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -2584,15 +2584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "input_buffer"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
-dependencies = [
- "bytes 1.1.0",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3172,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "multipart"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050aeedc89243f5347c3e237e3e13dc76fbe4ae3742a57b94dc14f69acf76d4"
+checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
 dependencies = [
  "buf_redux",
  "httparse",
@@ -3182,7 +3173,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "quick-error 1.2.3",
- "rand 0.7.3",
+ "rand 0.8.4",
  "safemem",
  "tempfile",
  "twoway",
@@ -4120,6 +4111,7 @@ dependencies = [
  "either",
  "ethers",
  "futures 0.3.17",
+ "futures-util",
  "git2",
  "librad",
  "outflux",
@@ -4134,6 +4126,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "warp",
 ]
 
 [[package]]
@@ -5338,19 +5331,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a5f475f1b9d077ea1017ecbc60890fda8e54942d680ca0b1d2b47cfa2d861b"
-dependencies = [
- "futures-util",
- "log",
- "pin-project 1.0.8",
- "tokio",
- "tungstenite 0.12.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
@@ -5361,7 +5341,7 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.14.0",
+ "tungstenite",
  "webpki",
  "webpki-roots",
 ]
@@ -5512,25 +5492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 dependencies = [
  "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
-dependencies = [
- "base64 0.13.0",
- "byteorder",
- "bytes 1.1.0",
- "http",
- "httparse",
- "input_buffer",
- "log",
- "rand 0.8.4",
- "sha-1",
- "url",
- "utf-8",
 ]
 
 [[package]]
@@ -5770,12 +5731,13 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
+checksum = "3cef4e1e9114a4b7f1ac799f16ce71c14de5778500c5450ec6b7b920c55b587e"
 dependencies = [
  "bytes 1.1.0",
- "futures 0.3.17",
+ "futures-channel",
+ "futures-util",
  "headers",
  "http",
  "hyper",
@@ -5792,7 +5754,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-tungstenite 0.13.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tower-service",
  "tracing",

--- a/org-node/Cargo.toml
+++ b/org-node/Cargo.toml
@@ -27,6 +27,8 @@ ethers = { version = "0.4" }
 rustc-hex = { version = "2.1" }
 anyhow = "1.0"
 outflux = { git = "https://github.com/radicle-dev/outflux", optional = true }
+warp = "0.3.2"
+futures-util = "0.3.17"
 
 [features]
 gcp = ["shared/gcp"]

--- a/org-node/src/client/handle.rs
+++ b/org-node/src/client/handle.rs
@@ -73,7 +73,7 @@ impl Handle {
         time::timeout(self.timeout, rx).await?.map_err(Error::from)
     }
 
-    pub async fn update_refs(&mut self, urn: Urn) -> Result<(), Error> {
+    pub async fn update_refs(&mut self, urn: Urn) -> Result<git2::Oid, Error> {
         let (tx, rx) = oneshot::channel();
         tracing::info!(target: "org-node", "Updating refs");
         self.channel
@@ -97,7 +97,7 @@ pub enum Request {
         std::time::Duration,
         oneshot::Sender<Result<Option<PeerId>, TrackProjectError>>,
     ),
-    UpdateRefs(Urn, oneshot::Sender<()>),
+    UpdateRefs(Urn, oneshot::Sender<git2::Oid>),
 }
 
 /// Error when using the [`Request::TrackProject`] request.

--- a/org-node/src/lib.rs
+++ b/org-node/src/lib.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 
 use futures::StreamExt;
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream};
 
 use std::collections::VecDeque;
 use std::convert::TryInto;
@@ -33,6 +33,7 @@ mod identity;
 #[cfg(feature = "influxdb-metrics")]
 mod metrics;
 mod query;
+mod webserver;
 
 pub use client::PeerId;
 pub use client::Urn;
@@ -53,6 +54,7 @@ pub struct Options {
     pub bootstrap: Vec<(PeerId, net::SocketAddr)>,
     pub rpc_url: String,
     pub listen: net::SocketAddr,
+    pub web_server_listen: net::SocketAddr,
     pub subgraph: String,
     pub orgs: Vec<OrgId>,
     pub urns: Vec<Urn>,
@@ -213,10 +215,17 @@ pub fn run(rt: tokio::runtime::Runtime, options: Options) -> anyhow::Result<()> 
     // Queue of events on orgs.
     let (update, events) = mpsc::channel(256);
 
-    let mut tasks: Vec<tokio::task::JoinHandle<()>> = Default::default();
+    // Websocket events channel
+    let (ws_tx, ws_rx) = mpsc::unbounded_channel::<webserver::WsEvent>();
+    let ws_rx = UnboundedReceiverStream::new(ws_rx);
 
+    let mut tasks: Vec<tokio::task::JoinHandle<()>> = Default::default();
     let client_handle_for_metrics = client.handle();
-    let client_task = rt.spawn(client.run(rt.handle().clone()));
+
+    let web_server = rt.spawn(webserver::serve(options.web_server_listen, ws_rx));
+    tasks.push(web_server);
+
+    let client_task = rt.spawn(client.run(rt.handle().clone(), ws_tx.clone()));
     tasks.push(client_task);
 
     let track_task = rt.spawn(track_projects(handle.clone(), queue));
@@ -233,7 +242,7 @@ pub fn run(rt: tokio::runtime::Runtime, options: Options) -> anyhow::Result<()> 
     let event_task = rt.spawn(subscribe_events(options.rpc_url.clone(), addresses, update));
     tasks.push(event_task);
 
-    let update_refs_task = rt.spawn(update_refs(handle));
+    let update_refs_task = rt.spawn(update_refs(handle, peer_id, ws_tx));
     tasks.push(update_refs_task);
 
     let query_task = rt.spawn(query_projects(
@@ -396,7 +405,11 @@ async fn subscribe_events(url: String, addresses: Vec<Address>, update: mpsc::Se
 }
 
 /// Stream Unix domain socket events and update refs for post-receive requests from the git-server.
-async fn update_refs(mut handle: client::Handle) {
+async fn update_refs(
+    mut handle: client::Handle,
+    peer_id: PeerId,
+    ws_tx: mpsc::UnboundedSender<webserver::WsEvent>,
+) {
     let path = std::env::temp_dir().join(ORG_SOCKET_FILE);
 
     // Remove the `org-node.sock` file on startup before rebinding;
@@ -410,13 +423,20 @@ async fn update_refs(mut handle: client::Handle) {
                         let stream = BufReader::new(s);
                         for urn in stream.lines().flatten() {
                             if let Ok(urn) = Urn::try_from_id(urn) {
-                                match handle.update_refs(urn).await {
-                                    Ok(()) => {
+                                match handle.update_refs(urn.clone()).await {
+                                    Ok(oid) => {
                                         tracing::info!(target: "org-node", "Successfully updated refs");
+                                        // Notify connected websocket clients of updated refs.
+                                        if let Err(e) = ws_tx.send(webserver::WsEvent::UpdatedRef {
+                                            oid,
+                                            urn,
+                                            peer: peer_id,
+                                        }) {
+                                            tracing::error!(target: "org-node", "Failed to send update refs notification to web socket clients: {}", e);
+                                        }
                                     }
                                     Err(e) => {
                                         tracing::error!(target: "org-node", "Failed to send update refs request to client: {}", e);
-                                        return;
                                     }
                                 }
                             }
@@ -424,7 +444,6 @@ async fn update_refs(mut handle: client::Handle) {
                     }
                     Err(e) => {
                         tracing::error!(target: "org-node", "Failed to open stream with error: {:?}", e);
-                        return;
                     }
                 }
             }

--- a/org-node/src/main.rs
+++ b/org-node/src/main.rs
@@ -20,6 +20,10 @@ pub struct Options {
     #[argh(option, default = "std::net::SocketAddr::from(([0, 0, 0, 0], 8776))")]
     pub listen: net::SocketAddr,
 
+    /// listen on the following address for web server events (default: 0.0.0.0:8336)
+    #[argh(option, default = "std::net::SocketAddr::from(([0, 0, 0, 0], 8336))")]
+    pub web_server_listen: net::SocketAddr,
+
     /// radicle root path, for key and git storage
     #[argh(option)]
     pub root: Option<PathBuf>,
@@ -92,6 +96,7 @@ impl From<Options> for node::Options {
         Self {
             root: other.root,
             listen: other.listen,
+            web_server_listen: other.web_server_listen,
             subgraph: other.subgraph,
             rpc_url: other.rpc_url,
             identity: other.identity,
@@ -119,6 +124,7 @@ impl From<Options> for node::Options {
         Self {
             root: other.root,
             listen: other.listen,
+            web_server_listen: other.web_server_listen,
             subgraph: other.subgraph,
             rpc_url: other.rpc_url,
             identity: other.identity,

--- a/org-node/src/webserver.rs
+++ b/org-node/src/webserver.rs
@@ -1,0 +1,181 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use futures_util::{SinkExt, StreamExt, TryFutureExt};
+use librad::{git::Urn, PeerId};
+use serde::Serialize;
+use tokio::sync::RwLock;
+use tokio::{
+    sync::mpsc::{self},
+    task::spawn,
+};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use warp::{
+    ws::{Message, WebSocket, Ws},
+    Filter,
+};
+
+/// Connected websocket client sender handles mapped by SocketAddr.
+type ConnectedWebSocketClients = Arc<RwLock<HashMap<SocketAddr, mpsc::UnboundedSender<WsEvent>>>>;
+
+/// Message type for establishing websocket sender.
+type EstablishWebSocketSender = (SocketAddr, mpsc::UnboundedSender<WsEvent>);
+
+// +----------------+
+// |                |    Receiver<WsEvent>
+// |  Main Process  +---------------------------+
+// |                |                           |
+// +-------+--------+                           |
+//         |                                    |
+//         | Sender<WsEvent>                    |
+//         |                                    |
+// +-------v--------+     +---------------------+---------------+-----+
+// |                |     |  Web Socket Process                 |     |
+// |   Client       |     |  (Spawned)                          |     |
+// |   Process      |     |                                     |     |
+// |   (Spawned)    |     |  Sender<WsEvent>                    |     |
+// |                |     |  Sender<EstablishWebSocketSender>   |     |
+// +----------------+     |                                     |     |
+//                        |  +----------------------------------v--+  |
+//                        |  | Connected Clients (Spawned)         |  |
+//                        |  |                                     |  |
+//                        |  | HashMap<SocketAddr,Sender<WsEvent>> |  |
+//                        |  | Receiver<WsEvent>                   |  |
+//                        |  | Receiver<EstablishWebSocketSender>  |  |
+//                        |  +-----^-+------------+-------------+--+  |
+//                        |        | |            |             |     |
+//                        +---+----+-+------+-----+---------+---+-----+
+//                            |      |      |     |         |   |
+//                        +---+------v+  +--+-----v---+  +--+---v-----+
+//                        |           |  |            |  |            |
+//                        | WS Client |  | WS Client  |  | WS Client  |
+//                        +-----------+  +------------+  +------------+
+
+/// Websocket server endpoint, e.g. ws://0.0.0.0:8336/subscribe
+pub const WEBSOCKET_PATH: &str = "subscribe";
+
+/// WebSocket event enum type to broadcast to connected websocket peers.
+#[derive(Debug, Clone, Serialize)]
+pub enum WsEvent {
+    UpdatedRef {
+        urn: Urn,
+        #[serde(serialize_with = "git_oid")]
+        oid: git2::Oid,
+        peer: PeerId,
+    },
+}
+
+/// helper method for serializing git2::Oid to a string
+fn git_oid<S>(oid: &git2::Oid, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&oid.to_string())
+}
+
+/// Establishes a websocket connection and sends new connected client event to message bus
+/// to update connected websocket client mapping to broadcast events to connected clients.
+async fn establish_connection(
+    websocket: WebSocket,
+    remote: SocketAddr,
+    conn_tx: mpsc::UnboundedSender<EstablishWebSocketSender>,
+) {
+    // Map the websocket stream to the channel
+    tracing::debug!(
+        target: "org-node",
+        "Received connection request from client address: {}", remote
+    );
+
+    let (mut peer_ws_tx, mut peer_ws_rx) = websocket.split();
+
+    // Use an unbounded channel to handle buffering and flushing of messages.
+    let (peer_unbounded_tx, peer_unbounded_rx) = mpsc::unbounded_channel::<WsEvent>();
+    let mut peer_unbounded_rx = UnboundedReceiverStream::new(peer_unbounded_rx);
+
+    // Listen for internal events and send to connected client.
+    spawn(async move {
+        while let Some(message) = peer_unbounded_rx.next().await {
+            if let Ok(msg) = serde_json::to_string(&message) {
+                peer_ws_tx
+                    .send(Message::text(msg))
+                    .unwrap_or_else(|e| {
+                        tracing::error!(target: "org-node", "websocket send error: {}", e);
+                    })
+                    .await;
+            }
+        }
+    });
+
+    // Send message to update connected web socket clients.
+    if let Err(e) = conn_tx.send((remote, peer_unbounded_tx)) {
+        tracing::error!(
+            target: "org-node",
+            "Failed to inform new websocket client connection: {}",
+            e
+        );
+    }
+
+    // Ignore incoming messages from the connected peer.
+    while let Some(msg) = peer_ws_rx.next().await {
+        // do nothing with the incoming message, subscription only.
+        drop(msg);
+    }
+}
+
+/// Serves a warp web server instance with a websocket endpoint for subscribing to events.
+pub async fn serve(listen: std::net::SocketAddr, mut events: UnboundedReceiverStream<WsEvent>) {
+    // Spawn connected clients receiver
+    let (conn_ws_tx, conn_ws_rx) = mpsc::unbounded_channel::<EstablishWebSocketSender>();
+    let mut conn_ws_rx = UnboundedReceiverStream::new(conn_ws_rx);
+
+    // instantiate an empty peer socket map;
+    let connected_ws_clients = ConnectedWebSocketClients::default();
+    let cloned_ws_clients = Arc::clone(&connected_ws_clients);
+
+    // listen for internal events and broadcast to connected peers.
+    tokio::task::spawn(async move {
+        while let Some(msg) = events.next().await {
+            // send update to all connected web socket clients.
+            for (addr, tx) in cloned_ws_clients.read().await.iter() {
+                if let Err(e) = tx.send(msg.clone()) {
+                    tracing::error!(target: "org-node", "Failed to send message to web socket client: {}", e);
+
+                    // Remove disconnected client from connected clients map.
+                    cloned_ws_clients.write().await.remove(addr);
+                }
+            }
+        }
+    });
+
+    // handle adding new connected websocket clients.
+    tokio::task::spawn(async move {
+        while let Some((addr, tx)) = conn_ws_rx.next().await {
+            connected_ws_clients.write().await.insert(addr, tx);
+        }
+    });
+
+    let connected_peers_filter = warp::any().map(move || conn_ws_tx.clone());
+
+    let routes = warp::path(WEBSOCKET_PATH)
+        .and(warp::addr::remote())
+        .and(warp::ws())
+        .and(connected_peers_filter)
+        .map(
+            move |remote: Option<SocketAddr>,
+                  ws: Ws,
+                  tx: mpsc::UnboundedSender<EstablishWebSocketSender>| {
+                ws.on_upgrade(move |socket| {
+                    establish_connection(
+                        socket,
+                        remote.expect("web socket clients should always have a socket address."),
+                        tx,
+                    )
+                })
+            },
+        );
+
+    tracing::info!(target: "org-node", "Web Server Listening on http://{}", listen);
+    tracing::info!(target: "org-node", "Web Socket Available at ws://{}/{}", listen, WEBSOCKET_PATH);
+    warp::serve(routes).run(listen).await;
+}


### PR DESCRIPTION
Enables events to be broadcasted to connected
websocket clients, such as when a ref is updated.

Signed-off-by: Ryan <ryan.michael.tate@gmail.com>