### PR TITLE
git-server: fix for optional allow unauth keys

### DIFF
--- a/git-server/src/hooks/pre_receive.rs
+++ b/git-server/src/hooks/pre_receive.rs
@@ -83,7 +83,7 @@ impl PreReceive {
         pre_receive.check_project_exists()?;
 
         // if allowed authorized keys is enabled, bypass the certificate check.
-        if pre_receive.env.allow_unauthorized_keys {
+        if pre_receive.env.allow_unauthorized_keys.is_some() {
             println!("SECURITY ALERT! UNAUTHORIZED KEYS ARE ALLOWED!");
             println!("Remove git-server flag `--allow-authorized-keys` to enforce GPG certificate verification");
             Ok(())

--- a/git-server/src/hooks/types.rs
+++ b/git-server/src/hooks/types.rs
@@ -96,7 +96,7 @@ pub struct ReceivePackEnv {
 
     /// allow unauthorized keys, ignores gpg certificate verification.
     #[envconfig(from = "RADICLE_ALLOW_UNAUTHORIZED_KEYS")]
-    pub allow_unauthorized_keys: bool,
+    pub allow_unauthorized_keys: Option<bool>,
 
     /// root directory where `git` directory is found.
     #[envconfig(from = "GIT_PROJECT_ROOT")]


### PR DESCRIPTION
fixes the case where --allow-unauthorized flag is
not set, and therefore neither is the ENV
RADICLE_ALLOW_UNAUTHORIZED_KEYS.

Adds Option<bool> and checks .is_some() in the
pre-receive hook.

Signed-off-by: Ryan <ryan.michael.tate@gmail.com>