### PR TITLE
Increment http-api version to 0.2.0

### DIFF
--- a/http-api/Cargo.toml
+++ b/http-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "radicle-http-api"
 license = "MIT OR Apache-2.0"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Alexis Sellier <self@cloudhead.io>"]
 edition = "2018"
 build = "../build.rs"


### PR DESCRIPTION
I propose to increment the version of the http-api to 0.2.0 due to the implementation of the project listing.

It would be helpful to check in the radicle-interface before querying the project list.