### PR TITLE
Trigger end-to-end tests on a pull request

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,29 @@
+name: Cargo
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: End-to-end tests
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Trigger e2e tests in a separate repo
+        uses: actions/github-script@v5
+        env:
+          SHA: $GITHUB_SHA
+        with:
+          github-token: ${{ secrets.TRIGGER_E2E_TESTS_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const { GITHUB_SHA } = process.env
+            await github.rest.actions.createWorkflowDispatch({
+                owner: 'radicle-dev',
+                repo: 'radicle-client-services-e2e-tests',
+                workflow_id: 'workflows/e2e-tests.yaml',
+                ref: 'main',
+                inputs: { client_services_commit_sha: GITHUB_SHA }
+            });


### PR DESCRIPTION
Triggers this GitHub Actions job: https://github.com/cloudhead/radicle-client-services-e2e-tests/runs/4471306560?check_suite_focus=true