### PR TITLE
Add remotes routes

### DIFF
--- a/http-api/src/error.rs
+++ b/http-api/src/error.rs
@@ -20,6 +20,10 @@ pub enum Error {
     #[error("missing delegations in project")]
     MissingDelegations,
 
+    /// Invalid branch name.
+    #[error("invalid branch name")]
+    BranchName,
+
     /// The entity was not found.
     #[error("entity not found")]
     NotFound,


### PR DESCRIPTION
This PR adds 2 new routes `/projects/<urn>/remotes` and `/projects/<urn>/remotes/<peerid>` which shows a list of remotes with replicated identities.
And reverts the peer id argument addition from the source code routes and project info.

It also refactors some querying into helper functions to reduce code duplication.