### PR TITLE
http-api: Utilize local state for project info

### DIFF
--- a/http-api/src/error.rs
+++ b/http-api/src/error.rs
@@ -16,9 +16,9 @@ pub enum Error {
     #[error("missing default branch in project")]
     MissingDefaultBranch,
 
-    /// The project does not have delegations.
-    #[error("missing delegations in project")]
-    MissingDelegations,
+    /// The project does not have a local state.
+    #[error("missing local state in project")]
+    MissingLocalState,
 
     /// Error related to tracking.
     #[error("tracking: {0}")]


### PR DESCRIPTION
This PR uses the local state of a project for checking the default branch head commit, and instead of going else for a remote branch it returns a 404 error