### PR TITLE
http-api: derive local head from delegates if none set

### DIFF
--- a/http-api/src/error.rs
+++ b/http-api/src/error.rs
@@ -16,10 +16,6 @@ pub enum Error {
     #[error("missing default branch in project")]
     MissingDefaultBranch,
 
-    /// The project does not have a local state.
-    #[error("missing local state in project")]
-    MissingLocalState,
-
     /// Error related to tracking.
     #[error("tracking: {0}")]
     Tracking(#[from] radicle_daemon::git::tracking::error::Tracked),
@@ -31,6 +27,10 @@ pub enum Error {
     /// The entity was not found.
     #[error("entity not found")]
     NotFound,
+
+    /// No local head found and unable to resolve from delegates.
+    #[error("could not resolve head: {0}")]
+    NoHead(&'static str),
 
     /// An error occured with radicle identities.
     #[error(transparent)]

--- a/http-api/src/project.rs
+++ b/http-api/src/project.rs
@@ -20,7 +20,7 @@ pub struct Info {
 }
 
 /// Project delegate.
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum Delegate {
     /// Direct delegation, ie. public key.


### PR DESCRIPTION
To make the `radicle-http-api` compatible with `upstream-seed` we fall back to calculating the current head from the project delegates instead of relying on it being set by the seed peer.