### PR TITLE
http-api: add support for RAD_HOME env var

### DIFF
--- a/http-api/src/main.rs
+++ b/http-api/src/main.rs
@@ -16,7 +16,7 @@ pub struct Options {
 
     /// radicle root path, for key and git storage
     #[argh(option)]
-    pub root: PathBuf,
+    pub root: Option<PathBuf>,
 
     /// TLS certificate path
     #[argh(option)]


### PR DESCRIPTION
This makes `radicle-http-api` aware of librad profiles by setting the RAD_HOME environment variable. The `--root` option behaves as before.