### PR TITLE
deps: remove radicle-daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
 dependencies = [
- "futures 0.3.18",
+ "futures",
  "pharos",
  "rustc_version",
 ]
@@ -1713,16 +1713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "fsevent"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,12 +1752,6 @@ name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
-name = "futures"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
@@ -1867,7 +1851,6 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
- "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1887,7 +1870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.18",
+ "futures",
  "memchr",
  "pin-project 0.4.28",
 ]
@@ -2232,7 +2215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06c5d2f987ee8f6dff3fa1a352058dc59b990e447e4c7846aa7d804971314f7b"
 dependencies = [
  "dashmap",
- "futures 0.3.18",
+ "futures",
  "futures-timer",
  "no-std-compat",
  "nonzero_ext",
@@ -2494,7 +2477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8ab7f67bad3240049cb24fb9cb0b4c2c6af4c245840917fbbdededeee91179"
 dependencies = [
  "async-io",
- "futures 0.3.18",
+ "futures",
  "futures-lite",
  "if-addrs",
  "ipnet",
@@ -2734,19 +2717,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c56bac60e13594bf7a8f12f7d592ece96ab30daa0fcaf533dfba2815838fc8e"
-dependencies = [
- "serde",
- "serde_json",
- "sled",
- "thiserror",
- "toml",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,7 +2785,7 @@ dependencies = [
  "deadpool",
  "directories",
  "either",
- "futures 0.3.18",
+ "futures",
  "futures_codec",
  "git-trailers",
  "git2",
@@ -2919,7 +2889,7 @@ version = "0.1.0"
 source = "git+https://github.com/radicle-dev/radicle-link?rev=b51ed772fe4ec2ae4fdb4e95bac0e3271be197c8#b51ed772fe4ec2ae4fdb4e95bac0e3271be197c8"
 dependencies = [
  "blocking",
- "futures 0.3.18",
+ "futures",
  "futures-util",
  "radicle-std-ext",
  "rand 0.8.4",
@@ -3751,7 +3721,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
- "futures 0.3.18",
+ "futures",
  "rustc_version",
 ]
 
@@ -3997,7 +3967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c82c0a393b300104f989f3db8b8637c0d11f7a32a9c214560b47849ba8f119aa"
 dependencies = [
  "bytes 1.1.0",
- "futures 0.3.18",
+ "futures",
  "lazy_static",
  "libc",
  "mio 0.7.14",
@@ -4037,29 +4007,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radicle-daemon"
-version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?rev=b51ed772fe4ec2ae4fdb4e95bac0e3271be197c8#b51ed772fe4ec2ae4fdb4e95bac0e3271be197c8"
-dependencies = [
- "anyhow",
- "async-stream",
- "either",
- "futures 0.3.18",
- "git2",
- "kv",
- "lazy_static",
- "librad",
- "nonempty 0.6.0",
- "radicle-git-ext",
- "radicle-git-helpers",
- "serde",
- "serde_millis",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "radicle-data"
 version = "0.1.0"
 source = "git+https://github.com/radicle-dev/radicle-link?rev=b51ed772fe4ec2ae4fdb4e95bac0e3271be197c8#b51ed772fe4ec2ae4fdb4e95bac0e3271be197c8"
@@ -4084,17 +4031,6 @@ dependencies = [
  "radicle-std-ext",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "radicle-git-helpers"
-version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?rev=b51ed772fe4ec2ae4fdb4e95bac0e3271be197c8#b51ed772fe4ec2ae4fdb4e95bac0e3271be197c8"
-dependencies = [
- "anyhow",
- "git2",
- "libgit2-sys",
- "librad",
 ]
 
 [[package]]
@@ -4131,7 +4067,7 @@ dependencies = [
  "async-trait",
  "either",
  "git2",
- "radicle-daemon",
+ "librad",
  "radicle-source",
  "serde",
  "serde_json",
@@ -4154,7 +4090,7 @@ dependencies = [
  "chacha20poly1305",
  "cryptovec",
  "ed25519-zebra",
- "futures 0.3.18",
+ "futures",
  "generic-array 0.14.4",
  "lazy_static",
  "rand 0.8.4",
@@ -4188,12 +4124,11 @@ dependencies = [
  "async-trait",
  "either",
  "ethers",
- "futures 0.3.18",
+ "futures",
  "futures-util",
  "git2",
  "librad",
  "outflux",
- "radicle-daemon",
  "rustc-hex",
  "serde",
  "serde_json",
@@ -4813,15 +4748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_millis"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e2dc780ca5ee2c369d1d01d100270203c4ff923d2a4264812d723766434d00"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4972,22 +4898,6 @@ name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
-
-[[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot",
-]
 
 [[package]]
 name = "smallvec"
@@ -5187,7 +5097,7 @@ dependencies = [
  "byteorder",
  "cryptovec",
  "data-encoding",
- "futures 0.3.18",
+ "futures",
  "log",
  "thiserror",
  "thrussh-encoding",
@@ -5438,7 +5348,7 @@ source = "git+https://github.com/radicle-dev/tracing-stackdriver.git#f161dad5e37
 dependencies = [
  "Inflector",
  "chrono",
- "futures 0.3.18",
+ "futures",
  "serde",
  "serde_json",
  "thiserror",
@@ -5800,7 +5710,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.18",
+ "futures",
  "js-sys",
  "parking_lot",
  "pin-utils",
@@ -5935,7 +5845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47ca1ab42f5afed7fc332b22b6e932ca5414b209465412c8cdf0ad23bc0de645"
 dependencies = [
  "async_io_stream",
- "futures 0.3.18",
+ "futures",
  "js-sys",
  "pharos",
  "rustc_version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,6 @@ members = [
   "shared",
 ]
 
-[patch.crates-io.radicle-daemon]
-git = "https://github.com/radicle-dev/radicle-link"
-rev = "b51ed772fe4ec2ae4fdb4e95bac0e3271be197c8"
-
 [patch.crates-io.librad]
 git = "https://github.com/radicle-dev/radicle-link"
 rev = "b51ed772fe4ec2ae4fdb4e95bac0e3271be197c8"

--- a/http-api/Cargo.toml
+++ b/http-api/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 build = "../build.rs"
 
 [dependencies]
+librad = { version = "0.1" }
 shared = { path = "../shared", default-features = false }
 warp = { version = "0.3.1", features = ["tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_urlencoded = { version = "0.7.0" }
 radicle-source = { version = "0.2.0", features = ["syntax"] }
-radicle-daemon = { version = "0.1.0" }
 thiserror = { version = "1" }
 git2 = { version = "0.13", default-features = false, features = [] }
 tokio = { version = "1.2", features = ["macros", "rt", "sync"] }

--- a/http-api/src/error.rs
+++ b/http-api/src/error.rs
@@ -18,7 +18,7 @@ pub enum Error {
 
     /// Error related to tracking.
     #[error("tracking: {0}")]
-    Tracking(#[from] radicle_daemon::git::tracking::error::Tracked),
+    Tracking(#[from] librad::git::tracking::error::Tracked),
 
     /// The entity was not found.
     #[error("entity not found")]
@@ -30,7 +30,7 @@ pub enum Error {
 
     /// An error occured with radicle identities.
     #[error(transparent)]
-    Identities(#[from] radicle_daemon::git::identities::Error),
+    Identities(#[from] librad::git::identities::Error),
 
     /// An error occured with radicle surf.
     #[error(transparent)]
@@ -38,11 +38,11 @@ pub enum Error {
 
     /// An error occured with radicle storage.
     #[error(transparent)]
-    Storage(#[from] radicle_daemon::git::storage::Error),
+    Storage(#[from] librad::git::storage::Error),
 
     /// An error occured with initializing read-only storage.
     #[error(transparent)]
-    Init(#[from] radicle_daemon::git::storage::read::error::Init),
+    Init(#[from] librad::git::storage::read::error::Init),
 
     /// An error occured with radicle source.
     #[error(transparent)]

--- a/http-api/src/lib.rs
+++ b/http-api/src/lib.rs
@@ -18,11 +18,11 @@ use warp::hyper::StatusCode;
 use warp::reply::Json;
 use warp::{self, filters::BoxedFilter, path, query, Filter, Rejection, Reply};
 
-use radicle_daemon::librad::git::identities;
-use radicle_daemon::librad::git::storage::read::ReadOnly;
-use radicle_daemon::librad::git::tracking;
-use radicle_daemon::librad::git::types::{One, Reference, Single};
-use radicle_daemon::{git::types::Namespace, profile::Profile, Paths, PeerId, Urn};
+use librad::git::identities;
+use librad::git::storage::read::ReadOnly;
+use librad::git::tracking;
+use librad::git::types::{One, Reference, Single};
+use librad::{git::types::Namespace, git::Urn, paths::Paths, profile::Profile, PeerId};
 use radicle_source::surf::file_system::Path;
 use radicle_source::surf::vcs::git;
 
@@ -58,7 +58,7 @@ pub struct Context {
 impl Context {
     /// Populates alias map with unique projects' names and their urns
     async fn populate_aliases(&self, map: &mut HashMap<String, Urn>) -> Result<(), Error> {
-        use radicle_daemon::git::identities::SomeIdentity::Project;
+        use librad::git::identities::SomeIdentity::Project;
 
         let storage = ReadOnly::open(&self.paths).expect("failed to open storage");
         let identities = identities::any::list(&storage)?;
@@ -534,7 +534,7 @@ async fn readme_handler(ctx: Context, project: Urn, sha: One) -> Result<impl Rep
 
 /// List all projects
 async fn project_root_handler(ctx: Context) -> Result<Json, Rejection> {
-    use radicle_daemon::git::identities::SomeIdentity;
+    use librad::git::identities::SomeIdentity;
 
     let storage = ReadOnly::open(&ctx.paths).map_err(Error::from)?;
     let repo = git::Repository::new(&ctx.paths.git_dir()).map_err(Error::from)?;
@@ -608,7 +608,7 @@ async fn tree_handler(
 
 /// List all projects that delegate is a part of.
 async fn delegates_projects_handler(ctx: Context, delegate: Urn) -> Result<impl Reply, Rejection> {
-    use radicle_daemon::git::identities::SomeIdentity;
+    use librad::git::identities::SomeIdentity;
 
     let storage = ReadOnly::open(&ctx.paths).map_err(Error::from)?;
     let repo = git::Repository::new(&ctx.paths.git_dir()).map_err(Error::from)?;

--- a/http-api/src/project.rs
+++ b/http-api/src/project.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::convert::TryFrom;
 
 use either::Either;
-use radicle_daemon::{PeerId, Urn};
+use librad::{git::Urn, PeerId};
 use serde::{Deserialize, Serialize};
 
 use crate::error;
@@ -55,10 +55,10 @@ pub struct Metadata {
     pub delegates: Vec<Delegate>,
 }
 
-impl TryFrom<radicle_daemon::Project> for Metadata {
+impl TryFrom<librad::identities::Project> for Metadata {
     type Error = error::Error;
 
-    fn try_from(project: radicle_daemon::Project) -> Result<Self, Self::Error> {
+    fn try_from(project: librad::identities::Project) -> Result<Self, Self::Error> {
         let subject = project.subject();
         let default_branch = subject
             .default_branch

--- a/org-node/Cargo.toml
+++ b/org-node/Cargo.toml
@@ -12,7 +12,6 @@ async-trait = { version = "0.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 git2 = { version = "0.13", default-features = false }
-radicle-daemon = { version = "0.1" }
 librad = { version = "0" }
 tokio = { version = "1", features = ["time", "rt", "rt-multi-thread"] }
 tokio-stream = { version = "0.1", default-features = false }

--- a/org-node/src/client.rs
+++ b/org-node/src/client.rs
@@ -87,7 +87,7 @@ pub enum Error {
     #[error("Join handle error: {0}")]
     TaskJoin(#[from] tokio::task::JoinError),
     #[error(transparent)]
-    RefStorage(#[from] Box<radicle_daemon::git::refs::stored::Error>),
+    RefStorage(#[from] Box<librad::git::refs::stored::Error>),
 }
 
 impl From<fetcher::Info> for Error {


### PR DESCRIPTION
This patch removes the use of the radicle-daemon package. The only use
of it was to import code from the re-exported librad package. Instead
we just use the librad dependency and import straight from there.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>