### PR TITLE
http-api: Improve pagination behaviour

### DIFF
--- a/http-api/src/lib.rs
+++ b/http-api/src/lib.rs
@@ -456,7 +456,13 @@ async fn history_handler(
         let mut result = radicle_source::commits::<PeerId>(browser, None)?;
 
         let page = page.unwrap_or(0);
-        let per_page = per_page.unwrap_or(30);
+
+        // If a pagination is defined, we do not want to paginate the commits, and we return all of them in the first page.
+        let per_page = if per_page.is_none() && (since.is_some() || until.is_some()) {
+            result.headers.len()
+        } else {
+            per_page.unwrap_or(30)
+        };
 
         let headers = result
             .headers


### PR DESCRIPTION
This PR is needed for a correct working of the code activity graphs in `radicle-interface`

- We limit the amount of commits to 30 when no date range is being passed i.e. `since` + `until`
- If a date range is passed we return all the commits inside that date range, on a single "page"