### PR TITLE
http-api: List patches

### DIFF
--- a/http-api/src/commit.rs
+++ b/http-api/src/commit.rs
@@ -2,7 +2,7 @@ use librad::PeerId;
 use radicle_source::commit::Header;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct CommitsQueryString {
     pub parent: Option<String>,
@@ -28,22 +28,22 @@ pub struct Commit {
     pub context: CommitContext,
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct CommitContext {
     pub committer: Option<Committer>,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Person {
     pub name: String,
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct Committer {
     pub peer: Peer,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Peer {
     pub id: PeerId,
     pub person: Option<Person>,

--- a/http-api/src/error.rs
+++ b/http-api/src/error.rs
@@ -24,6 +24,10 @@ pub enum Error {
     #[error("entity not found")]
     NotFound,
 
+    /// Failed to parse byte data into string.
+    #[error("not valid utf8")]
+    Utf8Error,
+
     /// No local head found and unable to resolve from delegates.
     #[error("could not resolve head: {0}")]
     NoHead(&'static str),

--- a/http-api/src/lib.rs
+++ b/http-api/src/lib.rs
@@ -461,6 +461,14 @@ async fn patches_handler(ctx: Context, urn: Urn) -> Result<impl Reply, Rejection
             for blob in blobs {
                 if let Some(object) = storage.find_object(blob.1).map_err(Error::from)? {
                     let tag = object.peel_to_tag().map_err(Error::from)?;
+                    // Only match tags that have a valid utf8 name that starts with patches/
+                    if !tag
+                        .name()
+                        .ok_or(Error::Utf8Error)?
+                        .starts_with("patches/")
+                    {
+                        continue;
+                    }
                     let merge_base = repo
                         .merge_base(info.head.unwrap(), tag.target_id())
                         .map_err(Error::from)?;

--- a/http-api/src/lib.rs
+++ b/http-api/src/lib.rs
@@ -461,12 +461,8 @@ async fn patches_handler(ctx: Context, urn: Urn) -> Result<impl Reply, Rejection
             for blob in blobs {
                 if let Some(object) = storage.find_object(blob.1).map_err(Error::from)? {
                     let tag = object.peel_to_tag().map_err(Error::from)?;
-                    // Only match tags that have a valid utf8 name that starts with patches/
-                    if !tag
-                        .name()
-                        .ok_or(Error::Utf8Error)?
-                        .starts_with("patches/")
-                    {
+                    // Only match tags that have a valid utf8 name that starts with `patches/`
+                    if !tag.name().ok_or(Error::Utf8Error)?.starts_with("patches/") {
                         continue;
                     }
                     let merge_base = repo
@@ -474,9 +470,9 @@ async fn patches_handler(ctx: Context, urn: Urn) -> Result<impl Reply, Rejection
                         .map_err(Error::from)?;
 
                     patches.push(Metadata {
-                        id: tag.name().unwrap().to_string(),
+                        id: tag.name().ok_or(Error::Utf8Error)?.to_string(),
                         peer: peer.clone(),
-                        message: Some(tag.message().unwrap().to_string()),
+                        message: tag.message().ok_or(Error::Utf8Error)?.to_string(),
                         commit: tag.target_id().to_string(),
                         merge_base: Some(merge_base.to_string()),
                     });

--- a/http-api/src/patch.rs
+++ b/http-api/src/patch.rs
@@ -3,16 +3,16 @@ use serde::{Deserialize, Serialize};
 
 /// A patch is a change set that a user wants the maintainer to merge into a projects default branch.
 ///
-/// A patch is represented by an annotated tag, prefixed with `radicle-patch/`.
+/// A patch is represented by an annotated tag, prefixed with `patches/`.
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Metadata {
-    /// ID of a patch. This is the portion of the tag name following the `radicle-patch/` prefix.
+    /// ID of a patch. This is the portion of the tag name following the `patches/` prefix.
     pub id: String,
     /// Peer that the patch originated from
     pub peer: Peer,
     /// Message attached to the patch. This is the message of the annotated tag.
-    pub message: Option<String>,
+    pub message: String,
     /// Head commit that the author wants to merge with this patch.
     pub commit: String,
     /// The merge base of [`Metadata::commit`] and the head commit of the first maintainer's default branch.

--- a/http-api/src/patch.rs
+++ b/http-api/src/patch.rs
@@ -1,0 +1,20 @@
+use crate::commit::Peer;
+use serde::{Deserialize, Serialize};
+
+/// A patch is a change set that a user wants the maintainer to merge into a projects default branch.
+///
+/// A patch is represented by an annotated tag, prefixed with `radicle-patch/`.
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Metadata {
+    /// ID of a patch. This is the portion of the tag name following the `radicle-patch/` prefix.
+    pub id: String,
+    /// Peer that the patch originated from
+    pub peer: Peer,
+    /// Message attached to the patch. This is the message of the annotated tag.
+    pub message: Option<String>,
+    /// Head commit that the author wants to merge with this patch.
+    pub commit: String,
+    /// The merge base of [`Metadata::commit`] and the head commit of the first maintainer's default branch.
+    pub merge_base: Option<String>,
+}


### PR DESCRIPTION
This PR adds a new filter and handler to able to query all the patches stored from the tracked peers.

Closes #143 