### PR TITLE
Update radicle-common patch rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4104,9 +4104,6 @@ name = "nonempty"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "nonzero_ext"
@@ -4861,7 +4858,7 @@ dependencies = [
 [[package]]
 name = "radicle-common"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-cli?rev=bb9e33dc4ff27d1259fc016cd96bd70f703aadc6#bb9e33dc4ff27d1259fc016cd96bd70f703aadc6"
+source = "git+https://github.com/radicle-dev/radicle-cli?rev=9bb8aa4eef0cda3c11c11e9fe1cd993d133bfb3d#9bb8aa4eef0cda3c11c11e9fe1cd993d133bfb3d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4881,7 +4878,6 @@ dependencies = [
  "lnk-identities",
  "lnk-profile",
  "log",
- "nonempty 0.7.0",
  "radicle-git-ext",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rev = "a9485b78b5c78d252c92f61d990cf34622d1c8f1"
 
 [patch.crates-io.radicle-common]
 git = "https://github.com/radicle-dev/radicle-cli"
-rev = "bb9e33dc4ff27d1259fc016cd96bd70f703aadc6"
+rev = "9bb8aa4eef0cda3c11c11e9fe1cd993d133bfb3d"
 
 [patch.crates-io.automerge]
 git = "https://github.com/automerge/automerge-rs"


### PR DESCRIPTION
Updates the revision used in the radicle-common patch section.
Without it the http-api crashes when trying to read comments.