### PR TITLE
http-api: Improve Siwe error output

### DIFF
--- a/http-api/src/lib.rs
+++ b/http-api/src/lib.rs
@@ -360,10 +360,10 @@ async fn recover(err: Rejection) -> Result<impl Reply, std::convert::Infallible>
         (StatusCode::NOT_FOUND, Some(msg.to_string()))
     } else if let Some(Error::Auth(msg)) = err.find::<Error>() {
         (StatusCode::BAD_REQUEST, Some(msg.to_string()))
-    } else if let Some(Error::SiweParseError(_)) = err.find::<Error>() {
-        (StatusCode::BAD_REQUEST, None)
-    } else if let Some(Error::SiweVerificationError(_)) = err.find::<Error>() {
-        (StatusCode::BAD_REQUEST, None)
+    } else if let Some(Error::SiweParseError(e)) = err.find::<Error>() {
+        (StatusCode::BAD_REQUEST, Some(e.to_string()))
+    } else if let Some(Error::SiweVerificationError(e)) = err.find::<Error>() {
+        (StatusCode::BAD_REQUEST, Some(e.to_string()))
     } else if let Some(err) = err.find::<warp::filters::body::BodyDeserializeError>() {
         (StatusCode::BAD_REQUEST, Some(err.to_string()))
     } else if let Some(Error::Git(e)) = err.find::<Error>() {


### PR DESCRIPTION
This PR makes use of the string passed to the `SiweVerificationError` and `SiweParserError`.