### PR TITLE
Two small fixes

### DIFF
--- a/.github/workflows/deployables.yml
+++ b/.github/workflows/deployables.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Fetch Caddyfile
         run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="curl https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/Caddyfile >Caddyfile"
       - name: Make room for new images
-        run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="docker system prune --force"
+        run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="docker system prune --all --force"
       - name: Pull container images
         run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="RADICLE_IMAGE_TAG=${{ github.sha }} docker-compose --file docker-compose.yml pull"
       - name: Stop services

--- a/git-server/Dockerfile
+++ b/git-server/Dockerfile
@@ -25,4 +25,5 @@ COPY --from=build /usr/src/radicle-client-services/git-server/docker/radicle-git
 
 WORKDIR /app/radicle
 
-ENTRYPOINT ["/usr/local/bin/radicle-git-server.sh", "--git-receive-pack", "--listen", "0.0.0.0:8778"]
+ENTRYPOINT ["/usr/local/bin/radicle-git-server.sh"]
+CMD ["--root", "/app/radicle/root", "--git-receive-pack", "--listen", "0.0.0.0:8778"]

--- a/git-server/docker/radicle-git-server.sh
+++ b/git-server/docker/radicle-git-server.sh
@@ -10,8 +10,7 @@ main () {
     radicle-service-init --root /app/radicle/root --identity /app/radicle/identity
     cp --force /usr/local/bin/pre-receive /app/radicle/root/git/hooks/pre-receive
     cp --force /usr/local/bin/post-receive /app/radicle/root/git/hooks/post-receive
-
-    exec /usr/local/bin/radicle-git-server --root /app/radicle/root "$@"
+    exec /usr/local/bin/radicle-git-server "$@"
 }
 
 main "$@"

--- a/http-api/Dockerfile
+++ b/http-api/Dockerfile
@@ -17,4 +17,5 @@ RUN echo deb http://deb.debian.org/debian bullseye-backports main contrib non-fr
 RUN apt-get update && apt-get install -y libssl1.1 && apt -t bullseye-backports install --yes git && rm -rf /var/lib/apt/lists/*
 COPY --from=build /usr/local/cargo/bin/radicle-http-api /usr/local/bin/radicle-http-api
 WORKDIR /app/radicle
-ENTRYPOINT ["/usr/local/bin/radicle-http-api", "--root", "/app/radicle/root", "--listen", "0.0.0.0:8777"]
+ENTRYPOINT ["/usr/local/bin/radicle-http-api"]
+CMD ["--root", "/app/radicle/root", "--listen", "0.0.0.0:8777"]


### PR DESCRIPTION
1) Purge old *tagged* docker images so that we don't run out of disk space
2) Easier overriding of e.g. `--root` for services