### PR TITLE
Various patches endpoint updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4628,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "radicle-common"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-cli?rev=bda4238767567c85ab935a0185f5f332be6ed5dd#bda4238767567c85ab935a0185f5f332be6ed5dd"
+source = "git+https://github.com/radicle-dev/radicle-cli?rev=2d362afef6c1b74610d61e34bd0c9a314d542b5a#2d362afef6c1b74610d61e34bd0c9a314d542b5a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4708,7 +4708,7 @@ dependencies = [
  "hex",
  "http",
  "librad",
- "radicle-source",
+ "radicle-source 0.3.0",
  "sha2 0.9.9",
  "shared",
  "thiserror",
@@ -4734,8 +4734,8 @@ dependencies = [
  "librad",
  "lnk-identities",
  "radicle-common",
- "radicle-source",
- "radicle-surf",
+ "radicle-source 0.4.0",
+ "radicle-surf 0.8.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4795,7 +4795,23 @@ dependencies = [
  "lazy_static",
  "log",
  "nonempty 0.6.0",
- "radicle-surf",
+ "radicle-surf 0.7.0",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "radicle-source"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577565375e3fd91fce9932f0bad9f52b22b772b0a14825168a7ee2c496144b71"
+dependencies = [
+ "base64 0.13.0",
+ "git2",
+ "lazy_static",
+ "log",
+ "nonempty 0.6.0",
+ "radicle-surf 0.8.0",
  "serde",
  "syntect",
  "thiserror",
@@ -4811,6 +4827,24 @@ name = "radicle-surf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1516a996d3e9254cace5331556ee5b340f921dc3f354b1f72352dc0542a74bee"
+dependencies = [
+ "anyhow",
+ "either",
+ "flate2",
+ "git2",
+ "nom 6.1.2",
+ "nonempty 0.5.0",
+ "regex",
+ "serde",
+ "tar",
+ "thiserror",
+]
+
+[[package]]
+name = "radicle-surf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d993c454d89baf57b567786151b8a1cbeac017ae0c2145dd2ceb85450150e7cd"
 dependencies = [
  "anyhow",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tag = "cycle/2022-06-21"
 
 [patch.crates-io.radicle-common]
 git = "https://github.com/radicle-dev/radicle-cli"
-rev = "bda4238767567c85ab935a0185f5f332be6ed5dd"
+rev = "2d362afef6c1b74610d61e34bd0c9a314d542b5a"
 
 [patch.crates-io.automerge]
 git = "https://github.com/automerge/automerge-rs"

--- a/http-api/Cargo.toml
+++ b/http-api/Cargo.toml
@@ -16,8 +16,8 @@ warp = { version = "0.3.1", features = ["tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_urlencoded = { version = "0.7.0" }
-radicle-source = { version = "0.3.0", features = ["syntax"] }
-radicle-surf = { version = "0.7.0", features = ["serialize"] }
+radicle-source = { version = "0.4.0", features = ["syntax"] }
+radicle-surf = { version = "0.8.0", features = ["serialize"] }
 radicle-common = { version = "0.1.0", features = ["ethereum"] }
 siwe = "0.2"
 thiserror = { version = "1" }

--- a/http-api/src/lib.rs
+++ b/http-api/src/lib.rs
@@ -47,7 +47,7 @@ use crate::project::{Info, PeerInfo};
 use commit::{Commit, CommitContext, CommitTeaser, CommitsQueryString, Committer};
 use error::Error;
 use issues::{issue_filter, issues_filter};
-use patches::patches_filter;
+use patches::{patch_filter, patches_filter};
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const POPULATE_FINGERPRINTS_INTERVAL: time::Duration = time::Duration::from_secs(20);
@@ -361,6 +361,7 @@ fn project_filters(ctx: Context) -> BoxedFilter<(impl Reply,)> {
         .or(blob_filter(ctx.clone()))
         .or(readme_filter(ctx.clone()))
         .or(patches_filter(ctx.clone()))
+        .or(patch_filter(ctx.clone()))
         .or(issue_filter(ctx.clone()))
         .or(issues_filter(ctx))
         .boxed()
@@ -1081,7 +1082,7 @@ fn get_head_commit(
     Ok(commit)
 }
 
-fn remote_branch(branch_name: &str, peer_id: &PeerId) -> git::Branch {
+pub fn remote_branch(branch_name: &str, peer_id: &PeerId) -> git::Branch {
     // NOTE<sebastinez>: We should be able to pass simply a branch name without heads/ and be able to query that later.
     // Needs work on radicle_surf I assume.
     git::Branch::remote(

--- a/http-api/src/patches.rs
+++ b/http-api/src/patches.rs
@@ -1,12 +1,21 @@
+use std::convert::TryFrom;
+use std::convert::TryInto;
+
 use warp::{self, path, Filter, Rejection, Reply};
 
 use librad::collaborative_objects::ObjectId;
-use librad::git::Urn;
+use librad::git::{identities, Storage, Urn};
+use librad::PeerId;
 
 use radicle_common::cobs::{patch, Store};
-use radicle_common::person;
+use radicle_common::{person, project};
+use radicle_source::commit::Stats;
+use radicle_source::surf::vcs::git;
+use radicle_source::Commit;
+use radicle_surf::diff;
 
 use crate::error::Error;
+use crate::remote_branch;
 use crate::Context;
 
 /// A collaborative object that includes its id.
@@ -23,6 +32,72 @@ impl<T: serde::Serialize> Cob<T> {
     }
 }
 
+#[derive(serde::Serialize, Clone)]
+struct Changeset {
+    commits: Vec<Commit>,
+    diff: git::Diff,
+    stats: Stats,
+}
+
+impl Changeset {
+    pub fn new(commits: Vec<Commit>, diff: git::Diff) -> Self {
+        Self {
+            commits,
+            stats: Changeset::stats(&diff),
+            diff,
+        }
+    }
+
+    // TODO: This function should probably be moved to radicle_surf, where it should be able to be called on radicle_surf::diff::Diff as associated function`
+    pub fn stats(diff: &git::Diff) -> Stats {
+        let mut deletions = 0;
+        let mut additions = 0;
+
+        for file in &diff.modified {
+            if let diff::FileDiff::Plain { ref hunks } = file.diff {
+                for hunk in hunks.iter() {
+                    for line in &hunk.lines {
+                        match line {
+                            diff::LineDiff::Addition { .. } => additions += 1,
+                            diff::LineDiff::Deletion { .. } => deletions += 1,
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        for file in &diff.created {
+            if let diff::FileDiff::Plain { ref hunks } = file.diff {
+                for hunk in hunks.iter() {
+                    for line in &hunk.lines {
+                        if let diff::LineDiff::Addition { .. } = line {
+                            additions += 1
+                        }
+                    }
+                }
+            }
+        }
+
+        for file in &diff.deleted {
+            if let diff::FileDiff::Plain { ref hunks } = file.diff {
+                for hunk in hunks.iter() {
+                    for line in &hunk.lines {
+                        if let diff::LineDiff::Deletion { .. } = line {
+                            deletions += 1
+                        }
+                    }
+                }
+            }
+        }
+
+        Stats {
+            additions,
+            deletions,
+        }
+    }
+}
+
 /// `GET /:project/patches`
 pub fn patches_filter(
     ctx: Context,
@@ -35,11 +110,36 @@ pub fn patches_filter(
         .and_then(patches_handler)
 }
 
+/// `GET /:project/patches/:id`
+pub fn patch_filter(ctx: Context) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    warp::get()
+        .map(move || ctx.clone())
+        .and(path::param::<Urn>())
+        .and(path("patches"))
+        .and(path::param::<ObjectId>())
+        .and(path::end())
+        .and_then(patch_handler)
+}
+
 async fn patches_handler(ctx: Context, urn: Urn) -> Result<impl Reply, Rejection> {
+    let repo = git::Repository::new(ctx.paths.git_dir()).map_err(Error::from)?;
     let storage = ctx.storage().await?;
+    let project = identities::project::get(storage.as_ref(), &urn)
+        .map_err(Error::Identities)?
+        .ok_or(Error::NotFound)?;
+    let meta: project::Metadata = project.try_into().map_err(Error::Project)?;
+
     let whoami = person::local(&*storage).map_err(Error::LocalIdentity)?;
     let store = Store::new(whoami, &ctx.paths, &storage).map_err(Error::from)?;
     let patches = patch::PatchStore::new(&store);
+
+    let mut browser = git::Browser::new_with_namespace(
+        &repo,
+        &git::Namespace::try_from(urn.encode_id().as_str()).map_err(|_| Error::MissingNamespace)?,
+        git::Branch::local(meta.default_branch.as_str()),
+    )
+    .map_err(Error::from)?;
+
     let all: Vec<_> = patches
         .all(&urn)
         .map_err(Error::Patches)?
@@ -52,9 +152,155 @@ async fn patches_handler(ctx: Context, urn: Urn) -> Result<impl Reply, Rejection
                 tracing::warn!("Failed to resolve identities in patch {}: {}", id, e);
             }
 
-            Cob::new(id, patch)
+            browser
+                .branch(remote_branch(
+                    meta.default_branch.as_str(),
+                    &patch.author.peer,
+                ))
+                .expect("Was not able to find {} in namespace and remote");
+
+            Cob::new(
+                id,
+                resolve_revisions(patch, &mut browser, &meta, &storage, false),
+            )
         })
         .collect();
 
     Ok(warp::reply::json(&all))
+}
+
+async fn patch_handler(
+    ctx: Context,
+    urn: Urn,
+    patch_id: ObjectId,
+) -> Result<impl Reply, Rejection> {
+    let repo = git::Repository::new(ctx.paths.git_dir()).map_err(Error::from)?;
+    let storage = ctx.storage().await?;
+    let project = identities::project::get(storage.as_ref(), &urn)
+        .map_err(Error::Identities)?
+        .ok_or(Error::NotFound)?;
+    let meta: project::Metadata = project.try_into().map_err(Error::Project)?;
+
+    let whoami = person::local(&*storage).map_err(Error::LocalIdentity)?;
+    let store = Store::new(whoami, &ctx.paths, &storage).map_err(Error::from)?;
+    let patches = patch::PatchStore::new(&store);
+    let mut patch = patches
+        .get(&urn, &patch_id)
+        .map_err(Error::from)?
+        .ok_or(Error::NotFound)?;
+    if let Err(e) = patch
+        .resolve(storage.as_ref())
+        .map_err(Error::IdentityResolve)
+    {
+        tracing::warn!("Failed to resolve identities in patch {}: {}", patch_id, e);
+    }
+
+    let mut browser = git::Browser::new_with_namespace(
+        &repo,
+        &git::Namespace::try_from(urn.encode_id().as_str()).map_err(|_| Error::MissingNamespace)?,
+        remote_branch(meta.default_branch.as_str(), &patch.author.peer),
+    )
+    .map_err(Error::from)?;
+
+    Ok(warp::reply::json(&Cob::new(
+        patch_id,
+        resolve_revisions(patch, &mut browser, &meta, &storage, true),
+    )))
+}
+
+// TODO: This function could eventually be moved to radicle-common and be part of Revision
+fn resolve_revisions(
+    patch: patch::Patch,
+    browser: &mut git::Browser,
+    meta: &project::Metadata,
+    storage: &Storage,
+    include_changeset: bool,
+) -> patch::Patch<Option<Changeset>, project::PeerInfo> {
+    let revisions = patch
+        .revisions
+        .into_iter()
+        .map(|revision| {
+            // Resolves Merge structs with PeerInfo
+            let merges = revision
+                .merges
+                .iter()
+                .map(|merge| {
+                    let peer = project::PeerInfo::get(&merge.peer, meta, storage);
+                    patch::Merge {
+                        peer,
+                        commit: merge.commit,
+                        timestamp: merge.timestamp,
+                    }
+                })
+                .collect();
+
+            // Locates the browser at the Oid of the current revision.
+            if let Err(e) = browser.rev(git::Rev::Oid(*revision.oid)) {
+                tracing::warn!(
+                    "Failed to set the browser history at {}: {}",
+                    *revision.oid,
+                    e
+                );
+
+                return patch::Revision {
+                    id: revision.id,
+                    peer: revision.peer,
+                    oid: revision.oid,
+                    base: revision.base,
+                    comment: revision.comment,
+                    discussion: revision.discussion,
+                    reviews: revision.reviews,
+                    timestamp: revision.timestamp,
+                    changeset: None,
+                    merges,
+                };
+            }
+
+            let mut changeset: Option<Changeset> = None;
+
+            if let (Ok(commits), Ok(diff), true) = (
+                radicle_source::commits::<PeerId>(browser, None),
+                // Gets the entire diff between the default branch head and the revision Oid.
+                browser.diff(*revision.base, *revision.oid),
+                // This feature flag, allows us to only generate diffs for e.g. single patch retrieval and skip all this for patch listing.
+                include_changeset,
+            ) {
+                // Iterates over commits headers and retrieves each commit details until it gets to the head of the default branch
+                // If radicle_source::commit returns a None the commit won't be collected.
+                let commits = commits
+                    .headers
+                    .iter()
+                    .take_while(|header| header.sha1 != *revision.base)
+                    .filter_map(|header| radicle_source::commit(browser, header.sha1).ok())
+                    .collect::<Vec<Commit>>();
+
+                changeset = Some(Changeset::new(commits, diff));
+            };
+
+            patch::Revision {
+                id: revision.id,
+                peer: revision.peer,
+                oid: revision.oid,
+                base: revision.base,
+                comment: revision.comment,
+                discussion: revision.discussion,
+                reviews: revision.reviews,
+                timestamp: revision.timestamp,
+                changeset,
+                merges,
+            }
+        })
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap(); // This unwrap is safe, since we work with a NonEmpty struct and won't collect an empty Vec.
+
+    patch::Patch {
+        author: patch.author,
+        title: patch.title,
+        state: patch.state,
+        target: patch.target,
+        labels: patch.labels,
+        timestamp: patch.timestamp,
+        revisions,
+    }
 }


### PR DESCRIPTION
This PR closes #155 

- Converts patch endpoints from using tags to COBs.
- Adds an endpoint for single patch retrieval
- Adds partial and complete diffs