### PR TITLE
a few minor fixes to api

### DIFF
--- a/http-api/src/lib.rs
+++ b/http-api/src/lib.rs
@@ -257,11 +257,13 @@ pub async fn run(options: Options) -> anyhow::Result<()> {
     if let (Some(cert), Some(key)) = (options.tls_cert, options.tls_key) {
         let config = RustlsConfig::from_pem_file(cert, key).await.unwrap();
 
+        tracing::info!("listening on https://{}", options.listen);
         axum_server::bind_rustls(options.listen, config)
             .serve(app.into_make_service())
             .await
             .unwrap();
     } else {
+        tracing::info!("listening on http://{}", options.listen);
         axum::Server::bind(&options.listen)
             .serve(app.into_make_service())
             .await

--- a/http-api/src/v1/projects.rs
+++ b/http-api/src/v1/projects.rs
@@ -35,7 +35,7 @@ pub fn router(ctx: Context) -> Router {
         .route("/projects/:project", get(project_alias_or_urn_handler))
         .route("/projects/:project/commits", get(history_handler))
         .route("/projects/:project/commits/:sha", get(commit_handler))
-        .route("/projects/:project/tree/:prefix/*path", get(tree_handler))
+        .route("/projects/:project/tree/:sha/*path", get(tree_handler))
         .route("/projects/:project/remotes", get(remotes_handler))
         .route("/projects/:project/remotes/:peer", get(remote_handler))
         .route("/projects/:project/blob/:sha/*path", get(blob_handler))
@@ -247,7 +247,7 @@ async fn project_alias_or_urn_handler(
 }
 
 /// Get project source tree.
-/// `GET /projects/:project/tree/:prefix/*path`
+/// `GET /projects/:project/tree/:sha/*path`
 async fn tree_handler(
     Extension(ctx): Extension<Context>,
     Path((project, sha, path)): Path<(Urn, One, String)>,


### PR DESCRIPTION
warp automatically would log the binding address on startup, e.g.:

```
Jul 25 14:42:23.464  INFO Server::run{addr=0.0.0.0:8778}: warp::server: listening on http://0.0.0.0:8777
```

axum doesn't so we add a manual log in https://github.com/radicle-dev/radicle-client-services/commit/d1e24ea22aefdcde55ac1c26ea760663903041ea

--------

in `/projects/:project/tree/:prefix/*path` route, renaming `:prefix` to `:sha` would make sense making it easier to understand.