### PR TITLE
http-api: Add project list pagination

### DIFF
--- a/http-api/src/project.rs
+++ b/http-api/src/project.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use librad::git::storage::ReadOnly;
 use librad::git::tracking;
@@ -6,6 +6,13 @@ use librad::git::tracking;
 pub use radicle_common::project::{Delegate, Metadata, PeerInfo};
 
 use crate::Error;
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct ProjectsQueryString {
+    pub page: Option<usize>,
+    pub per_page: Option<usize>,
+}
 
 /// Project info.
 #[derive(Serialize)]

--- a/http-api/src/v1.rs
+++ b/http-api/src/v1.rs
@@ -2,6 +2,7 @@ mod delegates;
 mod peer;
 mod projects;
 mod sessions;
+mod stats;
 
 use axum::Router;
 
@@ -10,6 +11,7 @@ use crate::Context;
 pub fn router(ctx: Context) -> Router {
     let routes = Router::new()
         .merge(peer::router(ctx.clone()))
+        .merge(stats::router(ctx.clone()))
         .merge(projects::router(ctx.clone()))
         .merge(sessions::router(ctx.clone()))
         .merge(delegates::router(ctx));

--- a/http-api/src/v1/stats.rs
+++ b/http-api/src/v1/stats.rs
@@ -1,0 +1,31 @@
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Extension, Json, Router};
+use librad::git::identities::{self, SomeIdentity};
+use serde_json::json;
+
+use crate::Context;
+use crate::Error;
+
+pub fn router(ctx: Context) -> Router {
+    Router::new()
+        .route("/stats", get(stats_handler))
+        .layer(Extension(ctx))
+}
+
+/// Return the stats for the node.
+/// `GET /stats`
+async fn stats_handler(Extension(ctx): Extension<Context>) -> impl IntoResponse {
+    let storage = ctx.storage().await?;
+    let (projects, persons): (Vec<_>, Vec<_>) = identities::any::list(storage.read_only())
+        .map_err(Error::from)?
+        .partition(|identity| match identity {
+            Ok(SomeIdentity::Project(_)) => true,
+            Ok(SomeIdentity::Person(_)) => false,
+            _ => panic!("Error while listing identities"),
+        });
+
+    Ok::<_, Error>(Json(
+        json!({ "projects": { "count": projects.len() }, "users": { "count": persons.len() } }),
+    ))
+}


### PR DESCRIPTION
This PR adds pagination to the project root handler.

- Creates chunks of size defined by query param `per_page` and defaults to 10 projects per page.
- Gets chunk at index defined by query param `page` and defaults to first page if None given.

We had some use cases where we queried for all projects of a seed, but currently we removed all this use cases.
If this still would be necessary, I would look for a way.

Also adds a project total count property to a new `/stats` route.