### PR TITLE
http-api: allow specifying color theme in http request

### DIFF
--- a/http-api/src/v1/projects.rs
+++ b/http-api/src/v1/projects.rs
@@ -414,6 +414,7 @@ async fn remote_handler(
 #[derive(Deserialize, Default)]
 struct BlobQuery {
     highlight: bool,
+    theme: Option<String>,
 }
 
 /// Get project source file.
@@ -426,7 +427,7 @@ async fn blob_handler(
     let path = path.strip_prefix('/').ok_or(Error::NotFound)?.to_string();
     let Query(query) = query.unwrap_or_default();
     let theme = if query.highlight {
-        Some(ctx.theme.as_str())
+        Some(query.theme.as_deref().unwrap_or(ctx.theme.as_str()))
     } else {
         None
     };


### PR DESCRIPTION
We allow setting the theme via the request, instead of configuring it via the CLI.
This allows us to implement theme switching in the UI, see: https://github.com/radicle-dev/radicle-interface/pull/298#issuecomment-1225715225.

The request would look like this:
http://127.0.0.1:8777/v1/projects/rad:git:hnrk8ueib11sen1g9n1xbt71qdns9n4gipw1o/blob/8604dc616b8531c672f4e1358a00770957bfbe94/svelte.config.js?highlight=true&theme=base16-ocean.light

If the `theme` query param isn't passed in, we fall back to the default `base16-ocean.dark` theme.