### PR TITLE
Switch to both a human- and machine- readable logging format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2700,6 +2700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4717,7 +4726,7 @@ dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
- "matchers",
+ "matchers 0.0.1",
  "regex",
  "serde",
  "serde_json",
@@ -4737,9 +4746,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
+ "lazy_static",
+ "matchers 0.1.0",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,7 +3585,7 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -3630,7 +3620,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -4220,8 +4210,8 @@ dependencies = [
  "radicle-common",
  "sha2 0.10.2",
  "tracing",
- "tracing-stackdriver",
- "tracing-subscriber",
+ "tracing-logfmt",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
@@ -4686,16 +4676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project 1.0.10",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4707,6 +4687,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-logfmt"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84279937c873ce4274feaaee53e2c503fce2d703bd284eecf04a6b94d7389ae"
+dependencies = [
+ "time 0.3.9",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.11",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4714,23 +4706,6 @@ checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
  "serde",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-stackdriver"
-version = "0.1.0"
-source = "git+https://github.com/radicle-dev/tracing-stackdriver.git#f161dad5e37249b14c35df78602471679747fe48"
-dependencies = [
- "Inflector",
- "chrono",
- "futures",
- "serde",
- "serde_json",
- "thiserror",
- "tracing-core",
- "tracing-futures",
- "tracing-serde",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -4753,6 +4728,20 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+dependencies = [
+ "ansi_term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/git-server/Cargo.toml
+++ b/git-server/Cargo.toml
@@ -47,6 +47,5 @@ hex = { version = "0.4.3", optional = true }
 
 [features]
 default = ["hooks"]
-gcp = ["shared/gcp"]
 hooks = ["envconfig", "hex"]
 

--- a/git-server/src/main.rs
+++ b/git-server/src/main.rs
@@ -5,8 +5,6 @@ use radicle_git_server as server;
 
 use argh::FromArgs;
 
-use shared::LogFmt;
-
 /// Radicle Git Server.
 #[derive(FromArgs)]
 pub struct Options {
@@ -29,10 +27,6 @@ pub struct Options {
     /// TLS key path
     #[argh(option)]
     pub tls_key: Option<PathBuf>,
-
-    /// either "plain" or "gcp" (gcp available only when compiled-in)
-    #[argh(option, default = "LogFmt::Plain")]
-    pub log_format: LogFmt,
 
     /// service 'git-receive-pack' operations, eg. resulting from a `git push` (default: false)
     #[argh(switch)]
@@ -72,7 +66,7 @@ impl From<Options> for server::Options {
 async fn main() {
     let options = Options::from_env();
 
-    shared::init_logger(options.log_format);
+    shared::init_logger();
     tracing::info!("version {}-{}", env!("CARGO_PKG_VERSION"), env!("GIT_HEAD"));
 
     match server::run(options.into()).await {

--- a/http-api/Cargo.toml
+++ b/http-api/Cargo.toml
@@ -38,6 +38,3 @@ tower-http = { version = "0.3.0", default-features = false, features = ["trace",
 
 [dev-dependencies]
 tower = { version = "0.4", features = ["util"] }
-
-[features]
-gcp = ["shared/gcp"]

--- a/http-api/src/main.rs
+++ b/http-api/src/main.rs
@@ -6,8 +6,6 @@ use radicle_http_api as api;
 
 use argh::FromArgs;
 
-use shared::LogFmt;
-
 /// Radicle HTTP API.
 #[derive(FromArgs)]
 pub struct Options {
@@ -34,10 +32,6 @@ pub struct Options {
     /// syntax highlight theme
     #[argh(option, default = r#"String::from("base16-ocean.dark")"#)]
     pub theme: String,
-
-    /// either "plain" or "gcp" (gcp available only when compiled-in)
-    #[argh(option, default = "LogFmt::Plain")]
-    pub log_format: LogFmt,
 }
 
 impl Options {
@@ -63,7 +57,7 @@ impl From<Options> for api::Options {
 async fn main() {
     let options = Options::from_env();
 
-    shared::init_logger(options.log_format);
+    shared::init_logger();
     tracing::info!("version {}-{}", env!("CARGO_PKG_VERSION"), env!("GIT_HEAD"));
 
     match api::run(options.into()).await {

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -11,7 +11,7 @@ byteorder = "1.4"
 librad = "0"
 sha2 = { version = "0.10.2" }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-logfmt = "0.1.2"
 radicle-common = { version = "0.1.0" }
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -11,10 +11,9 @@ byteorder = "1.4"
 librad = "0"
 sha2 = { version = "0.10.2" }
 tracing = "0.1"
-tracing-subscriber = "0.2"
-tracing-stackdriver = { git = "https://github.com/radicle-dev/tracing-stackdriver.git", optional = true }
+tracing-subscriber = "0.3"
+tracing-logfmt = "0.1.2"
 radicle-common = { version = "0.1.0" }
 
 [features]
 default = []
-gcp = ["tracing-stackdriver"]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -2,7 +2,7 @@ pub mod identity;
 pub mod signer;
 
 mod logging;
-pub use logging::{init_logger, LogFmt};
+pub use logging::init_logger;
 
 use std::path::PathBuf;
 

--- a/shared/src/logging.rs
+++ b/shared/src/logging.rs
@@ -1,52 +1,10 @@
-use std::str::FromStr;
+pub fn init_logger() {
+    use tracing::dispatcher::{self, Dispatch};
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Registry;
 
-#[derive(Clone, Copy)]
-pub enum LogFmt {
-    Plain,
+    let subscriber = Registry::default().with(tracing_logfmt::layer());
 
-    #[cfg(feature = "gcp")]
-    Gcp,
-}
-
-impl FromStr for LogFmt {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "plain" => Ok(LogFmt::Plain),
-
-            #[cfg(feature = "gcp")]
-            "gcp" => Ok(LogFmt::Gcp),
-
-            _ => Err("Unrecognized log format"),
-        }
-    }
-}
-
-pub fn init_logger(log_format: LogFmt) {
-    match log_format {
-        LogFmt::Plain => {
-            tracing_subscriber::fmt()
-                .with_ansi(false)
-                .with_env_filter(
-                    tracing_subscriber::EnvFilter::try_from_default_env()
-                        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-                )
-                .init();
-        }
-
-        #[cfg(feature = "gcp")]
-        LogFmt::Gcp => {
-            use tracing_stackdriver::Stackdriver;
-            use tracing_subscriber::Layer;
-            use tracing_subscriber::{layer::SubscriberExt, Registry};
-            let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
-            let stackdriver_layer = Stackdriver::default();
-            let subscriber = Registry::default().with(stackdriver_layer);
-            let result = env_filter.with_subscriber(subscriber);
-            tracing::subscriber::set_global_default(result)
-                .expect("Could not set up global logger");
-        }
-    }
+    dispatcher::set_global_default(Dispatch::new(subscriber))
+        .expect("Global logger has already been set!");
 }

--- a/shared/src/logging.rs
+++ b/shared/src/logging.rs
@@ -1,9 +1,12 @@
-pub fn init_logger() {
-    use tracing::dispatcher::{self, Dispatch};
-    use tracing_subscriber::layer::SubscriberExt;
-    use tracing_subscriber::Registry;
+use tracing::dispatcher::{self, Dispatch};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Registry;
 
-    let subscriber = Registry::default().with(tracing_logfmt::layer());
+pub fn init_logger() {
+    let subscriber = Registry::default()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .with(tracing_logfmt::layer());
 
     dispatcher::set_global_default(Dispatch::new(subscriber))
         .expect("Global logger has already been set!");


### PR DESCRIPTION
Sample:

```
ts=2022-08-30T09:21:24.261319Z level=info target=radicle_http_api message="version 0.2.0-c9f1d72"
ts=2022-08-30T09:21:24.262506Z level=info target=shared message="Profile REDACTED loaded..."
ts=2022-08-30T09:21:24.271943Z level=info target=radicle_http_api message="listening on http://0.0.0.0:8777"
ts=2022-08-30T09:21:36.622438Z level=info target=radicle_http_api message=Processed method=GET uri=/v1/projects status=200 latency=7.436997916s
```

It's parsable by Grafana Loki and thus it's possible to set up alerts based on logs.  Also, retires the dependency on GCP logs gathering in favor of Grafana Loki.