### PR TITLE
Add linkd service

### DIFF
--- a/.env.maple
+++ b/.env.maple
@@ -1,2 +1,2 @@
 RADICLE_DOMAIN=maple.radicle.garden
-RADICLE_GIT_SERVER_OPTS=--allow-unauthorized-keys
+RADICLE_GIT_SERVER_OPTS=--git-receive-pack --allow-unauthorized-keys

--- a/.env.pine
+++ b/.env.pine
@@ -1,2 +1,2 @@
 RADICLE_DOMAIN=pine.radicle.garden
-RADICLE_GIT_SERVER_OPTS=--allow-unauthorized-keys
+RADICLE_GIT_SERVER_OPTS=--git-receive-pack --allow-unauthorized-keys

--- a/.env.willow
+++ b/.env.willow
@@ -1,2 +1,2 @@
 RADICLE_DOMAIN=willow.radicle.garden
-RADICLE_GIT_SERVER_OPTS=--allow-unauthorized-keys
+RADICLE_GIT_SERVER_OPTS=--git-receive-pack --allow-unauthorized-keys

--- a/.github/workflows/deployables.yml
+++ b/.github/workflows/deployables.yml
@@ -78,8 +78,6 @@ jobs:
         run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="curl https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/.env.${{ matrix.host }} >.env"
       - name: Fetch docker-compose.yml
         run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="curl https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/docker-compose.yml >docker-compose.yml"
-      - name: Fetch Caddyfile
-        run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="curl https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/Caddyfile >Caddyfile"
       - name: Make room for new images
         run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="docker system prune --all --force"
       - name: Pull container images

--- a/.github/workflows/deployables.yml
+++ b/.github/workflows/deployables.yml
@@ -19,6 +19,16 @@ jobs:
           password: ${{ secrets.GCR_JSON_KEY }}
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Build and push linkd
+        id: linkd
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: linkd/Dockerfile
+          push: true
+          tags: gcr.io/radicle-services/linkd:latest,gcr.io/radicle-services/linkd:${{ github.sha }}
+          cache-from: type=registry,ref=gcr.io/radicle-services/linkd:latest
+          cache-to: type=inline
       - name: Build and push http-api
         id: http_api
         uses: docker/build-push-action@v2

--- a/.github/workflows/deployables.yml
+++ b/.github/workflows/deployables.yml
@@ -50,7 +50,7 @@ jobs:
           cache-from: type=registry,ref=gcr.io/radicle-services/git-server:latest
           cache-to: type=inline
 
-  deploy-images:
+  deploy-seed-node:
     runs-on: ubuntu-latest
     needs: build-and-push-images
     permissions:
@@ -58,10 +58,41 @@ jobs:
       id-token: 'write'
     strategy:
       matrix:
-        host: [seed, pine, willow, maple]
+        host: [seed]
         include:
         - host: seed
           zone: europe-west4-c
+    steps:
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          workload_identity_provider: 'projects/281042598092/locations/global/workloadIdentityPools/github-actions/providers/google-cloud'
+          service_account: 'github-actions@radicle-services.iam.gserviceaccount.com'
+      - name: Fetch host .env file
+        run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="curl https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/.env.${{ matrix.host }} >.env"
+      - name: Fetch docker-compose.yml
+        run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="curl https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/docker-compose.yml >docker-compose.yml"
+      - name: Fetch docker-compose.seed.yml
+        run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="curl https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/docker-compose.seed.yml >docker-compose.seed.yml"
+      - name: Make room for new images
+        run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="docker system prune --all --force"
+      - name: Pull container images
+        run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="RADICLE_IMAGE_TAG=${{ github.sha }} docker-compose --file docker-compose.yml --file docker-compose.seed.yml pull"
+      - name: Stop services
+        run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="RADICLE_IMAGE_TAG=${{ github.sha }} docker-compose --file docker-compose.yml --file docker-compose.seed.yml down"
+      - name: Restart services
+        run: gcloud beta compute ssh --zone ${{ matrix.zone }} "github-actions@alt-clients-${{ matrix.host }}" --project "radicle-services" --command="RADICLE_IMAGE_TAG=${{ github.sha }} docker-compose --file docker-compose.yml --file docker-compose.seed.yml up --detach"
+
+  deploy-garden-nodes:
+    runs-on: ubuntu-latest
+    needs: deploy-seed-node
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    strategy:
+      matrix:
+        host: [pine, willow, maple]
+        include:
         - host: pine
           zone: europe-north1-a
         - host: willow

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,0 @@
-{$RADICLE_DOMAIN} {
-    reverse_proxy git-server:8778
-}
-
-{$RADICLE_DOMAIN}:8777 {
-    reverse_proxy http-api:8777
-}

--- a/docker-compose.seed.yml
+++ b/docker-compose.seed.yml
@@ -1,0 +1,51 @@
+version: "3.7"
+services:
+  linkd:
+    image: gcr.io/radicle-services/linkd:${RADICLE_IMAGE_TAG:-latest}
+    ports:
+      - 8776:8776
+    entrypoint: /usr/local/bin/radicle-linkd --protocol-listen 0.0.0.0:8776 --lnk-home /app/radicle --track everything --signer key --key-format binary --key-source file --key-file-path /app/radicle/linkd.key
+    build:
+      dockerfile: ./linkd/Dockerfile
+      context: .
+    volumes:
+      - /var/opt/radicle:/app/radicle
+    environment:
+      RUST_LOG: info
+      RAD_HOME: /app/radicle
+    init: true
+    container_name: linkd
+    restart: unless-stopped
+    networks:
+      - radicle-services
+  caddy:
+    image: caddy:2.4.5
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        cat <<EOF >/etc/caddy/Caddyfile
+        {$RADICLE_DOMAIN} {
+            reverse_proxy git-server:8778
+        }
+
+        {$RADICLE_DOMAIN}:8777 {
+            reverse_proxy http-api:8777
+        }
+        EOF
+        caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+    ports:
+      - 80:80
+      - 443:443
+      - 8777:8777
+      - 8086:8086
+    environment:
+      RADICLE_DOMAIN: $RADICLE_DOMAIN
+    container_name: caddy
+    restart: unless-stopped
+    networks:
+      - radicle-services
+
+networks:
+  radicle-services:
+    name: radicle-services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,13 +40,25 @@ services:
           memory: 6gb
   caddy:
     image: caddy:2.4.5
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        cat <<EOF >/etc/caddy/Caddyfile
+        {$RADICLE_DOMAIN} {
+            reverse_proxy git-server:8778
+        }
+
+        {$RADICLE_DOMAIN}:8777 {
+            reverse_proxy http-api:8777
+        }
+        EOF
+        caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
     ports:
       - 80:80
       - 443:443
       - 8777:8777
       - 8086:8086
-    volumes:
-      - $PWD/Caddyfile:/etc/caddy/Caddyfile:ro
     environment:
       RADICLE_DOMAIN: $RADICLE_DOMAIN
     container_name: caddy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - git-server
   git-server:
     image: gcr.io/radicle-services/git-server:${RADICLE_IMAGE_TAG:-latest}
-    entrypoint: /usr/local/bin/radicle-git-server.sh --git-receive-pack $RADICLE_GIT_SERVER_OPTS --root /app/radicle --passphrase seed
+    entrypoint: /usr/local/bin/radicle-git-server.sh $RADICLE_GIT_SERVER_OPTS --root /app/radicle --passphrase seed
     build:
       dockerfile: ./git-server/Dockerfile
       context: .

--- a/linkd/Dockerfile
+++ b/linkd/Dockerfile
@@ -1,0 +1,23 @@
+# Build
+FROM rust:1.61.0-slim@sha256:91ab0966aa0d8eff103f42c04e0f4dd0bc628d1330942616a94bbe260f26fe6e as build
+
+RUN apt-get update && apt-get install -y pkg-config libssl-dev git cmake
+
+RUN git clone --depth 1 https://github.com/radicle-dev/radicle-link.git /usr/src/radicle-link
+WORKDIR /usr/src/radicle-link
+RUN git reset --hard 622c1bcd59a6ce584f957ffe6b874b2af0b207fd
+
+WORKDIR /usr/src/radicle-link/bins/linkd
+RUN set -eux; \
+    cargo install --locked --path .; \
+    objcopy --compress-debug-sections /usr/local/cargo/bin/linkd /usr/local/cargo/bin/radicle-linkd.compressed
+
+# Run
+FROM debian:bullseye-slim@sha256:4c25ffa6ef572cf0d57da8c634769a08ae94529f7de5be5587ec8ce7b9b50f9c
+
+EXPOSE 8777/tcp
+RUN echo deb http://deb.debian.org/debian bullseye-backports main contrib non-free >/etc/apt/sources.list.d/backports.list
+RUN apt-get update && apt-get install -y libssl1.1 && apt -t bullseye-backports install --yes git && rm -rf /var/lib/apt/lists/*
+COPY --from=build /usr/local/cargo/bin/radicle-linkd.compressed /usr/local/bin/radicle-linkd
+WORKDIR /app/radicle
+ENTRYPOINT ["/usr/local/bin/radicle-linkd", "--protocol-listen", "0.0.0.0:8776", "--lnk-home", "/app/radicle", "--track", "everything", "--signer", "key", "--key-format", "binary", "--key-source", "file", "--key-file-path", "/app/radicle/linkd.key"]


### PR DESCRIPTION
To resolve before deploying:

* [X] Decrypt existing keys and put them at `/var/opt/radicle/linkd.key`
* [X] ~~The existing data causes a startup failure: `linkd failed: signer key does not match the key used at initialisation`~~
* [ ] Not a blocker: Due to pulling linkd from a separate repo and the lack of `Cargo.lock`, current container image builds are not deterministic as Cargo may pick a different build plan each time.  We should introduce `Cargo.lock` into either of the repos.