### PR TITLE
storage: propose small improvements to control

### DIFF
--- a/node/src/client.rs
+++ b/node/src/client.rs
@@ -105,8 +105,8 @@ impl<R: Reactor> Client<R> {
     }
 
     /// Create a new handle to communicate with the client.
-    pub fn handle(&self) -> handle::Handle<R> {
-        handle::Handle {
+    pub fn handle(&self) -> handle::ClientAPI<R> {
+        handle::ClientAPI {
             waker: self.reactor.waker(),
             commands: self.handle.clone(),
             shutdown: self.shutdown.clone(),

--- a/node/src/client/handle.rs
+++ b/node/src/client/handle.rs
@@ -55,7 +55,7 @@ pub struct ClientAPI<R: Reactor> {
 
 impl<R: Reactor> traits::ClientAPI for ClientAPI<R> {
     /// Notify the client that a project has been updated.
-    fn updated(&self, id: ProjId) -> Result<(), Error> {
+    fn notify_update(&self, id: ProjId) -> Result<(), Error> {
         self.command(protocol::Command::AnnounceRefsUpdate(id))
     }
 
@@ -81,7 +81,7 @@ pub mod traits {
 
     pub trait ClientAPI {
         /// Notify the client that a project has been updated.
-        fn updated(&self, id: ProjId) -> Result<(), Error>;
+        fn notify_update(&self, id: ProjId) -> Result<(), Error>;
         /// Send a command to the command channel, and wake up the event loop.
         fn command(&self, cmd: protocol::Command) -> Result<(), Error>;
         /// Ask the client to shutdown.

--- a/node/src/client/handle.rs
+++ b/node/src/client/handle.rs
@@ -46,14 +46,14 @@ impl<T> From<chan::SendError<T>> for Error {
     }
 }
 
-pub struct Handle<R: Reactor> {
+pub struct ClientAPI<R: Reactor> {
     pub(crate) commands: chan::Sender<protocol::Command>,
     pub(crate) waker: R::Waker,
     pub(crate) shutdown: chan::Sender<()>,
     pub(crate) listening: chan::Receiver<net::SocketAddr>,
 }
 
-impl<R: Reactor> traits::Handle for Handle<R> {
+impl<R: Reactor> traits::ClientAPI for ClientAPI<R> {
     /// Notify the client that a project has been updated.
     fn updated(&self, id: ProjId) -> Result<(), Error> {
         self.command(protocol::Command::AnnounceRefsUpdate(id))
@@ -79,7 +79,7 @@ impl<R: Reactor> traits::Handle for Handle<R> {
 pub mod traits {
     use super::*;
 
-    pub trait Handle {
+    pub trait ClientAPI {
         /// Notify the client that a project has been updated.
         fn updated(&self, id: ProjId) -> Result<(), Error>;
         /// Send a command to the command channel, and wake up the event loop.

--- a/node/src/control.rs
+++ b/node/src/control.rs
@@ -65,7 +65,7 @@ fn drain<H: Handle>(stream: &UnixStream, handle: &H) -> Result<(), DrainError> {
     for line in reader.by_ref().lines().flatten() {
         match line.split_once(' ') {
             Some(("update", arg)) => {
-                if let Ok(id) = ProjId::from_str(arg) {
+                if let Ok(id) = arg.parse() {
                     if let Err(e) = handle.updated(id) {
                         return Err(DrainError::Client(e));
                     }

--- a/node/src/control.rs
+++ b/node/src/control.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use std::{fs, io, net};
 
 use crate::client;
-use crate::client::handle::traits::Handle;
+use crate::client::handle::traits::ClientAPI;
 use crate::identity::ProjId;
 
 /// Default name for control socket file.
@@ -21,7 +21,7 @@ pub enum Error {
 }
 
 /// Listen for commands on the control socket, and process them.
-pub fn listen<P: AsRef<Path>, H: Handle>(path: P, handle: H) -> Result<(), Error> {
+pub fn listen<P: AsRef<Path>, H: ClientAPI>(path: P, handle: H) -> Result<(), Error> {
     // Remove the socket file on startup before rebinding.
     fs::remove_file(&path).ok();
 
@@ -59,14 +59,14 @@ enum DrainError {
     Client(#[from] client::handle::Error),
 }
 
-fn drain<H: Handle>(stream: &UnixStream, handle: &H) -> Result<(), DrainError> {
+fn drain<S: ClientAPI>(stream: &UnixStream, srv: &S) -> Result<(), DrainError> {
     let mut reader = BufReader::new(stream);
 
     for line in reader.by_ref().lines().flatten() {
         match line.split_once(' ') {
             Some(("update", arg)) => {
                 if let Ok(id) = arg.parse() {
-                    if let Err(e) = handle.updated(id) {
+                    if let Err(e) = srv.updated(id) {
                         return Err(DrainError::Client(e));
                     }
                 } else {

--- a/node/src/control.rs
+++ b/node/src/control.rs
@@ -66,7 +66,7 @@ fn drain<S: ClientAPI>(stream: &UnixStream, srv: &S) -> Result<(), DrainError> {
         match line.split_once(' ') {
             Some(("update", arg)) => {
                 if let Ok(id) = arg.parse() {
-                    if let Err(e) = srv.updated(id) {
+                    if let Err(e) = srv.notify_update(id) {
                         return Err(DrainError::Client(e));
                     }
                 } else {

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -25,7 +25,7 @@ use crate::identity::{ProjId, Project, UserId};
 use crate::protocol::config::ProjectTracking;
 use crate::protocol::message::Message;
 use crate::protocol::peer::{Peer, PeerError, PeerState};
-use crate::storage::{self, ReadRepository, WriteRepository};
+use crate::storage::{self, ReadRepository, UpdateRepository};
 use crate::storage::{Inventory, WriteStorage};
 
 pub use crate::protocol::config::{Config, Network};

--- a/node/src/rad.rs
+++ b/node/src/rad.rs
@@ -9,7 +9,7 @@ use crate::git;
 use crate::identity::ProjId;
 use crate::storage::git::RADICLE_ID_REF;
 use crate::storage::refs::SignedRefs;
-use crate::storage::{BranchName, ReadRepository as _, WriteRepository as _};
+use crate::storage::{BranchName, ReadRepository as _, UpdateRepository as _};
 use crate::{identity, storage};
 
 pub const REMOTE_NAME: &str = "rad";

--- a/node/src/storage.rs
+++ b/node/src/storage.rs
@@ -166,7 +166,7 @@ pub trait ReadStorage {
 }
 
 pub trait WriteStorage<'r>: ReadStorage {
-    type Repository: WriteRepository<'r>;
+    type Repository: UpdateRepository<'r>;
 
     fn repository(&self, proj: &ProjId) -> Result<Self::Repository, Error>;
     fn sign_refs(&self, repository: &Self::Repository) -> Result<SignedRefs<Verified>, Error>;
@@ -189,7 +189,7 @@ pub trait ReadRepository<'r> {
     fn remotes(&'r self) -> Result<Self::Remotes, git2::Error>;
 }
 
-pub trait WriteRepository<'r>: ReadRepository<'r> {
+pub trait UpdateRepository<'r>: ReadRepository<'r> {
     fn fetch(&mut self, url: &Url) -> Result<(), git2::Error>;
     fn raw(&self) -> &git2::Repository;
 }

--- a/node/src/storage/git.rs
+++ b/node/src/storage/git.rs
@@ -15,7 +15,7 @@ use crate::identity::{ProjId, Project, UserId};
 use crate::storage::refs;
 use crate::storage::refs::{Refs, SignedRefs};
 use crate::storage::{
-    Error, Inventory, ReadRepository, ReadStorage, Remote, WriteRepository, WriteStorage,
+    Error, Inventory, ReadRepository, ReadStorage, Remote, UpdateRepository, WriteStorage,
 };
 
 use super::RemoteId;
@@ -303,7 +303,7 @@ impl<'r> ReadRepository<'r> for Repository {
     }
 }
 
-impl<'r> WriteRepository<'r> for Repository {
+impl<'r> UpdateRepository<'r> for Repository {
     /// Fetch all remotes of a project from the given URL.
     fn fetch(&mut self, url: &git::Url) -> Result<(), git2::Error> {
         // TODO: Have function to fetch specific remotes.
@@ -346,7 +346,7 @@ mod tests {
     use super::*;
     use crate::git;
     use crate::storage::refs::SIGNATURE_REF;
-    use crate::storage::{ReadStorage, WriteRepository};
+    use crate::storage::{ReadStorage, UpdateRepository};
     use crate::test::arbitrary;
     use crate::test::crypto::MockSigner;
     use crate::test::fixtures;

--- a/node/src/storage/refs.rs
+++ b/node/src/storage/refs.rs
@@ -17,7 +17,7 @@ use crate::crypto::{PublicKey, Signature, Signer, Unverified, Verified};
 use crate::git;
 use crate::git::Oid;
 use crate::storage;
-use crate::storage::{ReadRepository, RemoteId, WriteRepository};
+use crate::storage::{ReadRepository, RemoteId, UpdateRepository};
 
 pub static SIGNATURE_REF: Lazy<git::RefString> = Lazy::new(|| git::refname!("radicle/signature"));
 pub const REFS_BLOB_PATH: &str = "refs";
@@ -228,7 +228,7 @@ impl SignedRefs<Verified> {
 
     /// Save the signed refs to disk.
     /// This creates a new commit on the signed refs branch, and updates the branch pointer.
-    pub fn save<'r, S: WriteRepository<'r>>(
+    pub fn save<'r, S: UpdateRepository<'r>>(
         &self,
         // TODO: This should be part of the signed refs.
         remote: &RemoteId,

--- a/node/src/test/handle.rs
+++ b/node/src/test/handle.rs
@@ -10,7 +10,7 @@ pub struct Handle {
 }
 
 impl traits::ClientAPI for Handle {
-    fn updated(&self, id: identity::ProjId) -> Result<(), handle::Error> {
+    fn notify_update(&self, id: identity::ProjId) -> Result<(), handle::Error> {
         self.updates.lock().unwrap().push(id);
 
         Ok(())

--- a/node/src/test/handle.rs
+++ b/node/src/test/handle.rs
@@ -9,7 +9,7 @@ pub struct Handle {
     pub updates: Arc<Mutex<Vec<identity::ProjId>>>,
 }
 
-impl traits::Handle for Handle {
+impl traits::ClientAPI for Handle {
     fn updated(&self, id: identity::ProjId) -> Result<(), handle::Error> {
         self.updates.lock().unwrap().push(id);
 

--- a/node/src/test/storage.rs
+++ b/node/src/test/storage.rs
@@ -5,7 +5,7 @@ use crate::git;
 use crate::identity::{ProjId, Project, UserId};
 use crate::storage::refs;
 use crate::storage::{
-    Error, Inventory, ReadRepository, ReadStorage, Remote, RemoteId, WriteRepository, WriteStorage,
+    Error, Inventory, ReadRepository, ReadStorage, Remote, RemoteId, UpdateRepository, WriteStorage,
 };
 
 #[derive(Clone, Debug)]
@@ -121,7 +121,7 @@ impl ReadRepository<'_> for MockRepository {
     }
 }
 
-impl WriteRepository<'_> for MockRepository {
+impl UpdateRepository<'_> for MockRepository {
     fn fetch(&mut self, _url: &Url) -> Result<(), git2::Error> {
         Ok(())
     }


### PR DESCRIPTION
Rename the trait 'WriteRepository' to 'UpdateRepository'.  It describes
actions which updates repository state, but from data sources and actions
described by the arguments.  Not from data passed directly to the trait
methods.

Also:
 - rename trait
 - rename method