### PR TITLE
http-api: Set cache header for activity endpoint

### DIFF
--- a/http-api/Cargo.toml
+++ b/http-api/Cargo.toml
@@ -34,7 +34,7 @@ chrono = { version = "0.4.19", features = ["serde"] }
 axum = { version = "0.5.3", default-features = false, features = ["json", "headers", "query"] }
 axum-server = { version = "0.3", default-features = false, features = ["tls-rustls"] }
 hyper = { version ="0.14.17", default-features = false, features = ["server"] }
-tower-http = { version = "0.3.0", default-features = false, features = ["trace", "cors"] }
+tower-http = { version = "0.3.0", default-features = false, features = ["trace", "cors", "set-header"] }
 
 [dev-dependencies]
 tower = { version = "0.4", features = ["util"] }


### PR DESCRIPTION
Allow caching activity responses for an hour.

<img width="853" alt="Screenshot 2022-09-09 at 15 15 33" src="https://user-images.githubusercontent.com/158411/189358551-68d5f8d6-5b31-45f7-8257-dbbe652819e2.png">

This might improve loading times for subsequent visits of a seed index page, e.g. https://app.radicle.xyz/seeds/maple.radicle.garden.