### PR TITLE
Use `radicle_surf` `Commit` struct instead of `radicle_source`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3727,8 +3727,7 @@ dependencies = [
 [[package]]
 name = "radicle-surf"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d993c454d89baf57b567786151b8a1cbeac017ae0c2145dd2ceb85450150e7cd"
+source = "git+https://github.com/radicle-dev/radicle-git?rev=a11bedacaa075c07423254623ee7b91b5cb571a0#a11bedacaa075c07423254623ee7b91b5cb571a0"
 dependencies = [
  "anyhow",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ tag = "cycle/2022-07-12"
 git = "https://github.com/radicle-dev/radicle-link"
 tag = "cycle/2022-07-12"
 
+[patch.crates-io.radicle-surf]
+git = "https://github.com/radicle-dev/radicle-git"
+rev = "a11bedacaa075c07423254623ee7b91b5cb571a0"
+
 [patch.crates-io.radicle-common]
 git = "https://github.com/radicle-dev/radicle-cli"
 rev = "ea07d1c1327fd05e7792b771436744d415bf4fd9"

--- a/http-api/src/commit.rs
+++ b/http-api/src/commit.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use radicle_common::project::PeerInfo;
-use radicle_source::commit::Header;
-
+use radicle_surf::diff;
+use radicle_surf::vcs::git;
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct CommitsQueryString {
@@ -16,16 +16,16 @@ pub struct CommitsQueryString {
 
 #[derive(Serialize)]
 pub struct CommitTeaser {
-    pub header: Header,
+    pub header: git::Commit,
     pub context: CommitContext,
 }
 
 #[derive(Serialize)]
-pub struct Commit {
-    pub header: Header,
-    pub stats: radicle_source::commit::Stats,
-    pub diff: radicle_surf::diff::Diff,
-    pub branches: Vec<radicle_source::Branch>,
+pub struct Header {
+    pub header: git::Commit,
+    pub stats: diff::Stats,
+    pub diff: diff::Diff,
+    pub branches: Vec<git::BranchName>,
     pub context: CommitContext,
 }
 

--- a/http-api/src/commit.rs
+++ b/http-api/src/commit.rs
@@ -21,7 +21,7 @@ pub struct CommitTeaser {
 }
 
 #[derive(Serialize)]
-pub struct Header {
+pub struct Commit {
     pub header: git::Commit,
     pub stats: diff::Stats,
     pub diff: diff::Diff,

--- a/http-api/src/error.rs
+++ b/http-api/src/error.rs
@@ -4,8 +4,6 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde_json::json;
 
-use radicle_source::surf;
-
 /// Errors that may occur when interacting with [`librad::net::peer::Peer`].
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -55,7 +53,7 @@ pub enum Error {
 
     /// An error occurred with radicle surf.
     #[error(transparent)]
-    Surf(#[from] surf::git::error::Error),
+    Surf(#[from] radicle_surf::git::error::Error),
 
     /// An error occurred with radicle storage.
     #[error(transparent)]

--- a/http-api/src/lib.rs
+++ b/http-api/src/lib.rs
@@ -43,7 +43,7 @@ use librad::paths::Paths;
 use librad::PeerId;
 
 use radicle_common::{cobs, keys, person};
-use radicle_source::surf::vcs::git;
+use radicle_surf::vcs::git;
 
 use crate::auth::AuthState;
 use crate::project::{Info, PeerInfo};

--- a/http-api/src/v1/projects.rs
+++ b/http-api/src/v1/projects.rs
@@ -28,7 +28,7 @@ use radicle_surf::diff;
 use radicle_surf::vcs::git;
 
 use crate::axum_extra::{Path, Query};
-use crate::commit::{CommitContext, CommitTeaser, CommitsQueryString, Committer, Header};
+use crate::commit::{Commit, CommitContext, CommitTeaser, CommitsQueryString, Committer};
 use crate::project::{self, Info};
 use crate::{get_head_commit, Context, Error};
 
@@ -195,7 +195,7 @@ async fn commit_handler(
         .map(|b| b.name)
         .collect::<Vec<git::BranchName>>();
 
-    let response = Header {
+    let response = Commit {
         header: commit.clone(),
         stats: diff.stats(),
         diff,


### PR DESCRIPTION
This allows us to query parents of a commit and since radicle_source will eventually be deprecated, it prepares for it

Signed-off-by: Sebastian Martinez <me@sebastinez.dev>