### PR TITLE
Return 404 on bad paths

### DIFF
--- a/git-server/src/error.rs
+++ b/git-server/src/error.rs
@@ -150,6 +150,7 @@ impl Error {
             Error::Unauthorized(_) => http::StatusCode::UNAUTHORIZED,
             Error::KeyMismatch { .. } => http::StatusCode::UNAUTHORIZED,
             Error::AliasNotFound => http::StatusCode::NOT_FOUND,
+            Error::InvalidId => http::StatusCode::NOT_FOUND,
             _ => http::StatusCode::INTERNAL_SERVER_ERROR,
         }
     }


### PR DESCRIPTION
Requests like `GET /favicon.ico/` currently result in 5xx error tripping alerts spuriously.  This PR makes it so that 404 is returned instead.