### PR TITLE
http-api: Change the iterator to not count failed projects

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -54,7 +54,6 @@ jobs:
         with:
           profile: minimal
           components: clippy, rustfmt
-          toolchain: 1.64
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3614,6 +3614,7 @@ dependencies = [
  "futures",
  "git2",
  "hyper",
+ "itertools",
  "librad",
  "lnk-identities",
  "radicle-common",

--- a/http-api/Cargo.toml
+++ b/http-api/Cargo.toml
@@ -35,6 +35,7 @@ axum = { version = "0.5.3", default-features = false, features = ["json", "heade
 axum-server = { version = "0.3", default-features = false, features = ["tls-rustls"] }
 hyper = { version ="0.14.17", default-features = false, features = ["server"] }
 tower-http = { version = "0.3.0", default-features = false, features = ["trace", "cors", "set-header"] }
+itertools = "0.10"
 
 [dev-dependencies]
 tower = { version = "0.4", features = ["util"] }

--- a/http-api/src/project.rs
+++ b/http-api/src/project.rs
@@ -15,7 +15,7 @@ pub struct ProjectsQueryString {
 }
 
 /// Project info.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Info {
     /// Project metadata.


### PR DESCRIPTION
To avoid returning a lesser amount of projects then requested, we get the project info during the iterator and paginate after filtering for invalid projects.

This removes the ability to fetch projects in parallel, but fixes the issue of returning less projects then requested for.

PS. If someone has an idea to fetch in parallel during the iterator, please feel free to commit to this PR or lmk how you would do it.

Closes #205 