### PR TITLE
http-api: Add `max-age` attribute to CORS headers

### DIFF
--- a/http-api/src/lib.rs
+++ b/http-api/src/lib.rs
@@ -240,6 +240,7 @@ pub async fn run(options: Options) -> anyhow::Result<()> {
         .merge(v1::router(ctx.clone()))
         .layer(
             CorsLayer::new()
+                .max_age(Duration::from_secs(86400))
                 .allow_origin(cors::Any)
                 .allow_methods([Method::GET, Method::POST, Method::PUT])
                 .allow_headers([CONTENT_TYPE, AUTHORIZATION]),


### PR DESCRIPTION
We should inform browsers to cache CORS preflight requests for at least 24h. This safes us in the best case multiple roundtrips between the app and the http-api.

Closes #197 